### PR TITLE
Add support for DDR transfers & minor fixes

### DIFF
--- a/litespi/clkgen.py
+++ b/litespi/clkgen.py
@@ -40,15 +40,13 @@ class LiteSPIClkGen(Module):
         self.clk     = clk     = Signal()
         self.en      = en      = Signal()
         cnt          = Signal(8)
-        clkd         = Signal()
 
         self.comb += [
-            posedge.eq(clk & ~clkd),
-            negedge.eq(~clk & clkd),
+            posedge.eq(~clk & (cnt == div)),
+            negedge.eq(clk & (cnt == div)),
         ]
 
         self.sync += [
-            clkd.eq(clk),
             If(en,
                 If(cnt < div,
                     cnt.eq(cnt+1),

--- a/litespi/clkgen.py
+++ b/litespi/clkgen.py
@@ -12,8 +12,15 @@ class LiteSPIClkGen(Module):
     ----------
     pads : Object
         SPI pads description.
+
     device : str
         Device type for determining how to get output pin if it was not provided in pads.
+
+    cnt_width : int
+        Width of the internal counter ``cnt`` used for dividing the clock.
+
+    with_ddr : bool
+        Generate additional ``sample`` and ``update`` signals.
 
     Attributes
     ----------
@@ -32,18 +39,36 @@ class LiteSPIClkGen(Module):
     en : Signal(), in
         Clock enable input, output clock will be generated if set to 1, 0 resets the core.
 
+    sample : Signal(), out
+        Outputs 1 when ``sample_cnt==cnt``, can be used to sample incoming DDR data.
+
+    sample_cnt : Signal(8), in
+        Controls generation of the ``sample`` signal.
+
+    update : Signal(), out
+        Outputs 1 when ``update_cnt==cnt``, can be used to update outgoing DDR data.
+
+    update_cnt : Signal(8), in
+        Controls generation of the ``update`` signal.
     """
-    def __init__(self, pads, device):
-        self.div     = div     = Signal(8)
-        self.posedge = posedge = Signal()
-        self.negedge = negedge = Signal()
-        self.clk     = clk     = Signal()
-        self.en      = en      = Signal()
-        cnt          = Signal(8)
+    def __init__(self, pads, device, cnt_width=8, with_ddr=False):
+        self.div        = div        = Signal(cnt_width)
+        self.sample_cnt = sample_cnt = Signal(cnt_width)
+        self.update_cnt = update_cnt = Signal(cnt_width)
+        self.posedge    = posedge    = Signal()
+        self.negedge    = negedge    = Signal()
+        self.sample     = sample     = Signal()
+        self.update     = update     = Signal()
+        self.clk        = clk        = Signal()
+        self.en         = en         = Signal()
+        cnt             = Signal(cnt_width)
+
 
         self.comb += [
             posedge.eq(~clk & (cnt == div)),
             negedge.eq(clk & (cnt == div)),
+            sample.eq(cnt == sample_cnt),
+            update.eq(cnt == update_cnt),
         ]
 
         self.sync += [

--- a/litespi/phy/generic.py
+++ b/litespi/phy/generic.py
@@ -133,12 +133,12 @@ class LiteSPIPHY(Module):
         )
         fsm.act("CMD",
             dq_oe.eq(cmd_oe_mask),
-            dq_o.eq(cmd[-1] if cmd_width == 1 else cmd[-cmd_width:]),
+            dq_o.eq(cmd[-cmd_width:]),
             self.shift_out(cmd_width, cmd_bits, "ADDR", op=[NextValue(cmd, cmd<<cmd_width)], trigger=clkgen.negedge, ddr=False),
         )
         fsm.act("ADDR",
             dq_oe.eq(addr_oe_mask[addr_width]),
-            dq_o.eq(addr[-1] if addr_width == 1 else addr[-addr_width:]),
+            dq_o.eq(addr[-addr_width:]),
             self.shift_out(addr_width, len(addr), "DUMMY", op=[NextValue(addr, addr<<addr_width)], trigger=clkgen.negedge if not ddr else clkgen.update, ddr=ddr)
         )
         fsm.act("DUMMY",

--- a/litespi/phy/generic.py
+++ b/litespi/phy/generic.py
@@ -7,12 +7,13 @@ from litespi.common import *
 from litex.soc.interconnect import stream
 
 # Output enable masks for the tri-state buffers, data mode mask is not included as oe pins default to 0
-cmd_oe_mask = 0b0001
-soft_oe_mask = 0b0001
+cmd_oe_mask  = 0b00000001
+soft_oe_mask = 0b00000001
 addr_oe_mask = {
-    1: 0b0001,
-    2: 0b0011,
-    4: 0b1111,
+    1: 0b00000001,
+    2: 0b00000011,
+    4: 0b00001111,
+    8: 0b11111111,
 }
 
 def GetConfig(flash=None):
@@ -26,7 +27,7 @@ class LiteSPIPHY(Module):
 
     The ``LiteSPIPHY`` class provides a generic PHY that can be connected to the ``LiteSPICore``.
 
-    It supports single/dual/quad output reads from the flash chips.
+    It supports single/dual/quad/octal output reads from the flash chips.
 
     Parameters
     ----------
@@ -96,7 +97,7 @@ class LiteSPIPHY(Module):
         else:
             bus_width = len(pads.dq)
 
-        assert bus_width in [1, 2, 4]
+        assert bus_width in [1, 2, 4, 8]
 
         dq_o  = Signal(len(pads.dq))
         dq_i  = Signal(len(pads.dq))

--- a/litespi/phy/generic.py
+++ b/litespi/phy/generic.py
@@ -19,8 +19,8 @@ addr_oe_mask = {
 def GetConfig(flash=None):
     if flash is None:
         # TODO: replace with a named tuple/configuration object
-        # addr_bits, dummy_bits, cmd_width, addr_width, data_width, command
-        return (24, 8, 1, 1, 1, 0x0b)
+        # addr_bits, dummy_bits, cmd_width, addr_width, data_width, command, ddr access
+        return (24, 8, 1, 1, 1, 0x0b, False)
 
 class LiteSPIPHY(Module):
     """Generic LiteSPI PHY
@@ -52,10 +52,12 @@ class LiteSPIPHY(Module):
         Flash CS signal.
 
     """
-    def shift_out(self, width, bits, next_state, negedge_op=None, posedge_op=None):
+    def shift_out(self, width, bits, next_state, trigger=None, op=None, ddr=False):
+        edge = self.clkgen.negedge if not ddr else trigger
+
         res = [
             self.clkgen.en.eq(1),
-            If(self.clkgen.negedge,
+            If(edge,
                 NextValue(self.fsm_cnt, self.fsm_cnt+width),
                 If(self.fsm_cnt == (bits-width),
                     NextValue(self.fsm_cnt, 0),
@@ -64,11 +66,8 @@ class LiteSPIPHY(Module):
             ),
         ]
 
-        if negedge_op is not None:
-            res += [If(self.clkgen.negedge, *negedge_op)]
-
-        if posedge_op is not None:
-            res += [If(self.clkgen.posedge, *posedge_op)]
+        if trigger is not None and op is not None:
+            res += [If(trigger, *op)]
 
         return res
 
@@ -78,15 +77,17 @@ class LiteSPIPHY(Module):
 
         self.cs_n     = Signal()
 
-        self.submodules.clkgen = clkgen = LiteSPIClkGen(pads, device)
+        addr_bits, dummy_bits, cmd_width, addr_width, data_width, command, ddr = GetConfig(flash)
 
-        addr_bits, dummy_bits, cmd_width, addr_width, data_width, command = GetConfig(flash)
+        self.submodules.clkgen = clkgen = LiteSPIClkGen(pads, device, with_ddr=ddr)
 
         data_bits = 32
         cmd_bits = 8
 
         self.comb += [
-            clkgen.div.eq(2), # should be SoftCPU configurable
+            clkgen.div.eq(2), # TODO: clkgen options should be SoftCPU configurable
+            clkgen.sample_cnt.eq(1),
+            clkgen.update_cnt.eq(1),
             pads.cs_n.eq(self.cs_n),
             pads.clk.eq(clkgen.clk),
         ]
@@ -112,8 +113,8 @@ class LiteSPIPHY(Module):
                 t.oe.eq(dq_oe[i]),
             ]
 
-        self.fsm_cnt = Signal(max=31)
-        addr         = Signal(addr_bits)
+        self.fsm_cnt = Signal(8)
+        addr         = Signal(addr_bits if not ddr else addr_bits+addr_width) # dummy data for the first register shift
         data         = Signal(data_bits)
         cmd          = Signal(cmd_bits)
 
@@ -133,19 +134,19 @@ class LiteSPIPHY(Module):
         fsm.act("CMD",
             dq_oe.eq(cmd_oe_mask),
             dq_o.eq(cmd[-1] if cmd_width == 1 else cmd[-cmd_width:]),
-            self.shift_out(cmd_width, cmd_bits, "ADDR", negedge_op=[NextValue(cmd, cmd<<cmd_width)]),
+            self.shift_out(cmd_width, cmd_bits, "ADDR", op=[NextValue(cmd, cmd<<cmd_width)], trigger=clkgen.negedge, ddr=False),
         )
         fsm.act("ADDR",
             dq_oe.eq(addr_oe_mask[addr_width]),
             dq_o.eq(addr[-1] if addr_width == 1 else addr[-addr_width:]),
-            self.shift_out(addr_width, addr_bits, "DUMMY", negedge_op=[NextValue(addr, addr<<addr_width)]),
+            self.shift_out(addr_width, len(addr), "DUMMY", op=[NextValue(addr, addr<<addr_width)], trigger=clkgen.negedge if not ddr else clkgen.update, ddr=ddr)
         )
         fsm.act("DUMMY",
             If(self.fsm_cnt < 8, dq_oe.eq(addr_oe_mask[addr_width])), # output 0's for the first dummy byte
             self.shift_out(addr_width, dummy_bits, "IDLE"),
         )
         fsm.act("DATA",
-            self.shift_out(data_width, data_bits, "SEND_DATA", posedge_op=[NextValue(data, Cat(dq_i[1] if data_width == 1 else dq_i[0:data_width], data))]),
+            self.shift_out(data_width, data_bits, "SEND_DATA", op=[NextValue(data, Cat(dq_i[1] if data_width == 1 else dq_i[0:data_width], data))], trigger=clkgen.posedge if not ddr else clkgen.sample, ddr=ddr)
         )
         fsm.act("SEND_DATA",
             source.valid.eq(1),

--- a/litespi/phy/generic.py
+++ b/litespi/phy/generic.py
@@ -141,6 +141,7 @@ class LiteSPIPHY(Module):
             self.shift_out(addr_width, addr_bits, "DUMMY", negedge_op=[NextValue(addr, addr<<addr_width)]),
         )
         fsm.act("DUMMY",
+            If(self.fsm_cnt < 8, dq_oe.eq(addr_oe_mask[addr_width])), # output 0's for the first dummy byte
             self.shift_out(addr_width, dummy_bits, "IDLE"),
         )
         fsm.act("DATA",


### PR DESCRIPTION
This PR mainly adds support for the DDR mode of operation where address and data is transferred on both edges of the clock. This has only been tested in `litex_sim` but the resulting timing diagrams seem to match ones in `S25FL128S` datasheet which I used as a reference on DDR transfers in SPI flashes.

Other minor changes are:
- Added support for octal mode chips.
- Clkgen posedge & negedge are now asserted in the cycle in which the `clk` value changes and not in the one after that.
- Command & address register indexing has been simplified.
- Cleaned up `shift_out` method.