### PR TITLE
litespi: delay signals in clkgen by 1 cycle due to usage of SDRTristate

### DIFF
--- a/litespi/clkgen.py
+++ b/litespi/clkgen.py
@@ -65,7 +65,8 @@ class LiteSPIClkGen(Module, AutoDoc, ModuleDoc):
         en_int          = Signal()
         clk             = Signal()
 
-        self.comb += [
+        # Delay signals by 1 cycle due to usage of SDRTristate
+        self.sync += [
             posedge.eq(~clk & (cnt == div)),
             negedge.eq(clk & (cnt == div)),
             sample.eq(cnt == sample_cnt),


### PR DESCRIPTION
The issue was non-delayed signals in clkgen which are needed when we use SDRTristate.
PR adds changes which delay clkgen signals by 1 cycle.

Closes #32 