### PR TITLE
Add clkdiv and dummybits CSRs

### DIFF
--- a/litespi/__init__.py
+++ b/litespi/__init__.py
@@ -41,12 +41,16 @@ class LiteSPI(Module, AutoCSR, AutoDoc, ModuleDoc):
         bus : Interface(), out
             Wishbone interface for memory-mapped flash access.
     """
-    def __init__(self, phy, with_mmap=True, with_master=True, mmap_endianness="big"):
+    def __init__(self, phy, sys_clk_freq, with_mmap=True, with_master=True, mmap_endianness="big", default_divisor=9):
         assert with_mmap or with_master
 
         self._cfg = CSRStorage(fields=[
             CSRField("mux_sel", size=1, offset=0, description="SPI PHY multiplexer bit (0=SPIMMAP module attached to PHY, 1=SPI Master attached to PHY)")
         ])
+
+        self.clk_divisor  = clk_div  = CSRStorage(8, reset=default_divisor)
+        self.sys_clk_freq = clk_freq = CSRStatus(32)
+        self.comb += clk_freq.status.eq(sys_clk_freq)
 
         self.submodules.crossbar = crossbar = LiteSPICrossbar(self._cfg.fields.mux_sel)
 
@@ -70,4 +74,5 @@ class LiteSPI(Module, AutoCSR, AutoDoc, ModuleDoc):
             crossbar.master.source.connect(phy.sink),
             phy.source.connect(crossbar.master.sink),
             phy.cs_n.eq(crossbar.cs_n),
+            phy.clkgen.div.eq(self.clk_divisor.storage),
         ]

--- a/litespi/__init__.py
+++ b/litespi/__init__.py
@@ -48,8 +48,9 @@ class LiteSPI(Module, AutoCSR, AutoDoc, ModuleDoc):
             CSRField("mux_sel", size=1, offset=0, description="SPI PHY multiplexer bit (0=SPIMMAP module attached to PHY, 1=SPI Master attached to PHY)")
         ])
 
-        self.clk_divisor  = clk_div  = CSRStorage(8, reset=default_divisor)
-        self.sys_clk_freq = clk_freq = CSRStatus(32)
+        self.clk_divisor  = clk_div    = CSRStorage(8, reset=default_divisor)
+        self.dummy_bits   = dummy_bits = CSRStorage(8, reset=phy.default_dummy_bits)
+        self.sys_clk_freq = clk_freq   = CSRStatus(32)
         self.comb += clk_freq.status.eq(sys_clk_freq)
 
         self.submodules.crossbar = crossbar = LiteSPICrossbar(self._cfg.fields.mux_sel)
@@ -75,4 +76,5 @@ class LiteSPI(Module, AutoCSR, AutoDoc, ModuleDoc):
             phy.source.connect(crossbar.master.sink),
             phy.cs_n.eq(crossbar.cs_n),
             phy.clkgen.div.eq(self.clk_divisor.storage),
+            phy.dummy_bits.eq(dummy_bits.storage)
         ]

--- a/litespi/phy/generic.py
+++ b/litespi/phy/generic.py
@@ -83,7 +83,9 @@ class LiteSPIPHY(Module, AutoDoc, ModuleDoc):
         self.source = source = stream.Endpoint(spi_phy_data_layout)
         self.sink   = sink   = stream.Endpoint(spi_phy_ctl_layout)
 
-        self.cs_n     = Signal()
+        self.cs_n               = Signal()
+        self.default_dummy_bits = flash.dummy_bits if flash.fast_mode else 0
+        self.dummy_bits         = dummy_bits = Signal(8)
 
         if hasattr(pads, "miso"):
             bus_width = 1
@@ -97,7 +99,6 @@ class LiteSPIPHY(Module, AutoDoc, ModuleDoc):
         assert flash.check_bus_width(bus_width)
 
         addr_bits = flash.addr_bits
-        dummy_bits = flash.dummy_bits if flash.fast_mode else 0
         cmd_width = flash.cmd_width
         addr_width = flash.addr_width
         data_width = flash.bus_width
@@ -180,7 +181,11 @@ class LiteSPIPHY(Module, AutoDoc, ModuleDoc):
         fsm.act("ADDR",
             dq_oe.eq(addr_oe_mask[addr_width]),
             dq_o.eq(addr[-addr_width:]),
-            self.shift_out(addr_width, len(addr), "DUMMY" if dummy_bits else "IDLE", op=[NextValue(addr, addr<<addr_width)], trigger=clkgen.negedge if not ddr else clkgen.update, ddr=ddr)
+            If(dummy_bits > 0,
+                self.shift_out(addr_width, len(addr), "DUMMY", op=[NextValue(addr, addr<<addr_width)], trigger=clkgen.negedge if not ddr else clkgen.update, ddr=ddr)
+            ).Else(
+                self.shift_out(addr_width, len(addr), "IDLE", op=[NextValue(addr, addr<<addr_width)], trigger=clkgen.negedge if not ddr else clkgen.update, ddr=ddr)
+            )
         )
         fsm.act("DUMMY",
             If(self.fsm_cnt < 8, dq_oe.eq(addr_oe_mask[addr_width])), # output 0's for the first dummy byte

--- a/litespi/phy/generic.py
+++ b/litespi/phy/generic.py
@@ -110,7 +110,6 @@ class LiteSPIPHY(Module, AutoDoc, ModuleDoc):
         cmd_bits = 8
 
         self.comb += [
-            clkgen.div.eq(2), # TODO: clkgen options should be SoftCPU configurable
             clkgen.sample_cnt.eq(1),
             clkgen.update_cnt.eq(1),
             pads.cs_n.eq(self.cs_n),


### PR DESCRIPTION
PR adds CSRs for clkdiv and dummy bits to configure them from e.g. BIOS.
Additionally I added a CSR status to store sys clk frequency - this is used only to calculate frequency during runtime.