### PR TITLE
Add optional litespi wrapping into separate clock domain

### DIFF
--- a/examples/arty.py
+++ b/examples/arty.py
@@ -86,11 +86,12 @@ class BaseSoC(SoCCore):
 
         # SPIFlash ---------------------------------------------------------------------------------
         if with_spiflash:
-            self.submodules.spiflash_phy  = LiteSPIPHY(platform.request("spiflash"), S25FL128S(Codes.READ_1_1_1))
-            self.submodules.spiflash_mmap = LiteSPI(phy=self.spiflash_phy,
-                sys_clk_freq    = sys_clk_freq,
+            self.submodules.spiflash_phy    = LiteSPIPHY(platform.request("spiflash"), S25FL128S(Codes.READ_1_1_1))
+            self.submodules.spiflash_mmap   = LiteSPI(phy=self.spiflash_phy,
+                clk_freq        = sys_clk_freq,
                 mmap_endianness = self.cpu.endianness)
             self.add_csr("spiflash_mmap")
+            self.add_csr("spiflash_phy")
             spiflash_size   = 1024*1024*16
             spiflash_region = SoCRegion(origin=self.mem_map.get("spiflash", None), size=spiflash_size, cached=False)
             self.bus.add_slave(name="spiflash", slave=self.spiflash_mmap.bus, region=spiflash_region)


### PR DESCRIPTION
This PR introduces changes which give a possibility to have LiteSPI in a separate clock domain.
The only doubt I have is do we have to pipeline the data from CSRs (which are in sys clock domain) to litespi clock domain using e.g. AsynFIFOs? I mean these [registers](https://github.com/litex-hub/litespi/pull/38/files#diff-76745ba1ce398bffc095fd8450e49fcdL51-L52). I tested on Arty board two configurations:
- LiteSPI in `sys` clock domain
- LiteSPI in `clk200` clock domain

in each cases I was able to successfully read from flash.

Closes #23 