### PR TITLE
Add arbitration

### DIFF
--- a/litespi/__init__.py
+++ b/litespi/__init__.py
@@ -20,7 +20,7 @@ class LiteSPICore(Module):
     def __init__(self):
         self.source = stream.Endpoint(spi_phy_ctl_layout)
         self.sink   = stream.Endpoint(spi_phy_data_layout)
-        self.cs_n   = Signal()
+        self.cs     = Signal()
 
 
 class LiteSPI(Module, AutoCSR, AutoDoc, ModuleDoc):
@@ -33,7 +33,7 @@ class LiteSPI(Module, AutoCSR, AutoDoc, ModuleDoc):
     Parameters
     ----------
     phy : Module
-        Module or object that contains PHY stream interfaces and a cs_n signal to connect the ``LiteSPICore`` to.
+        Module or object that contains PHY stream interfaces and a cs signal to connect the ``LiteSPICore`` to.
 
     clk_freq : int
         Frequency of a clock connected to LiteSPI.
@@ -65,11 +65,11 @@ class LiteSPI(Module, AutoCSR, AutoDoc, ModuleDoc):
         self.comb += sys_clk_freq.status.eq(clk_freq)
 
         self.submodules.crossbar = crossbar = LiteSPICrossbar(self._cfg.fields.mux_sel, clock_domain)
-        self.comb += phy.cs_n.eq(crossbar.cs_n)
+        self.comb += phy.cs.eq(crossbar.cs)
 
         if with_mmap:
             self.submodules.mmap = mmap = LiteSPIMMAP(mmap_endianness)
-            port_mmap = crossbar.get_port(MMAP_PORT, mmap.cs_n)
+            port_mmap = crossbar.get_port(MMAP_PORT, mmap.cs)
             self.bus = mmap.bus
             self.comb += [
                 port_mmap.source.connect(mmap.sink),
@@ -77,7 +77,7 @@ class LiteSPI(Module, AutoCSR, AutoDoc, ModuleDoc):
             ]
         if with_master:
             self.submodules.master = master = LiteSPIMaster()
-            port_master = crossbar.get_port(MASTER_PORT, master.cs_n)
+            port_master = crossbar.get_port(MASTER_PORT, master.cs)
             self.comb += [
                 port_master.source.connect(master.sink),
                 master.source.connect(port_master.sink),

--- a/litespi/__init__.py
+++ b/litespi/__init__.py
@@ -83,7 +83,7 @@ class LiteSPI(Module, AutoCSR, AutoDoc, ModuleDoc):
                 master.source.connect(port_master.sink),
             ]
 
-        if clock_domain is not "sys":
+        if clock_domain != "sys":
             self.comb += [
                 crossbar.tx_cdc.source.connect(phy.sink),
                 phy.source.connect(crossbar.rx_cdc.sink),

--- a/litespi/common.py
+++ b/litespi/common.py
@@ -31,7 +31,4 @@ spi_phy_data_layout = [
     ("data", 32),
 ]
 
-MMAP_PORT   = 0
-MASTER_PORT = 1
-
 MMAP_DEFAULT_TIMEOUT = 256

--- a/litespi/common.py
+++ b/litespi/common.py
@@ -33,3 +33,5 @@ spi_phy_data_layout = [
 
 MMAP_PORT   = 0
 MASTER_PORT = 1
+
+MMAP_DEFAULT_TIMEOUT = 256

--- a/litespi/core/master.py
+++ b/litespi/core/master.py
@@ -36,7 +36,7 @@ class LiteSPIMaster(Module, AutoCSR):
     sink : Endpoint(spi_phy_ctl_layout), in
         Control stream.
 
-    cs_n : Signal(), out
+    cs : Signal(), out
         Slave CS signal.
 
     """
@@ -51,7 +51,7 @@ class LiteSPIMaster(Module, AutoCSR):
 
         assert self.sink.data.nbits == self.source.data.nbits
 
-        self.cs_n = Signal(cs_width)
+        self.cs = Signal(cs_width)
 
         self._cs = CSRStorage(cs_width)
         self._phyconfig = CSRStorage(fields=[
@@ -68,7 +68,7 @@ class LiteSPIMaster(Module, AutoCSR):
         # # #
 
         # SPI CS.
-        self.comb += self.cs_n.eq(~self._cs.storage)
+        self.comb += self.cs.eq(self._cs.storage)
 
         # SPI TX (MOSI).
         self.comb += [

--- a/litespi/core/mmap.py
+++ b/litespi/core/mmap.py
@@ -36,14 +36,14 @@ class LiteSPIMMAP(Module):
     bus : Interface(), out
         Wishbone interface for memory-mapped flash access.
 
-    cs_n : Signal(), out
-        CS signal for the flash chip, should be connected to cs_n signal of the PHY.
+    cs : Signal(), out
+        CS signal for the flash chip, should be connected to cs signal of the PHY.
     """
     def __init__(self, endianness="big"):
         self.source = source = stream.Endpoint(spi_phy_ctl_layout)
         self.sink   = sink   = stream.Endpoint(spi_phy_data_layout)
         self.bus    = bus    = wishbone.Interface()
-        self.cs_n   = cs_n   = Signal()
+        self.cs     = cs     = Signal()
 
         # # #
 
@@ -60,12 +60,12 @@ class LiteSPIMMAP(Module):
         # FSM.
         self.submodules.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
-            cs_n.eq(1),
             If(bus_read,
                 NextState("CS-DELAY"),
             )
         )
         fsm.act("CMD",
+            cs.eq(1),
             source.valid.eq(1),
             source.cmd.eq(CMD),
             source.data.eq(Cat(Signal(2), bus.adr)), # Words to Bytes.
@@ -75,6 +75,7 @@ class LiteSPIMMAP(Module):
             )
         )
         fsm.act("READ-REQ",
+            cs.eq(1),
             source.valid.eq(1),
             source.cmd.eq(READ),
             If(source.ready,
@@ -83,6 +84,7 @@ class LiteSPIMMAP(Module):
             )
         )
         fsm.act("READ-DAT",
+            cs.eq(1),
             sink.ready.eq(bus.stb),
             bus.ack.eq(sink.valid),
             If(sink.valid & sink.ready,
@@ -91,6 +93,7 @@ class LiteSPIMMAP(Module):
             )
         )
         fsm.act("READY",
+            cs.eq(1),
             If(bus_read,
                 # If Bus Address matches Current Address: We can do the access directly in current SPI Burst.
                 If(bus.adr == curr_addr,
@@ -102,7 +105,6 @@ class LiteSPIMMAP(Module):
             )
         )
         fsm.act("CS-DELAY",
-            cs_n.eq(1),
             If(cs_count < 10000, # FIXME: Make it configurable.
                 NextValue(cs_count, cs_count + 1),
             ).Else(

--- a/litespi/crossbar.py
+++ b/litespi/crossbar.py
@@ -8,10 +8,10 @@
 from collections import OrderedDict
 
 from migen import *
+from migen.genlib.roundrobin import RoundRobin
 from litespi.common import *
 
 from litex.soc.interconnect import stream
-from litex.soc.interconnect.packet import Arbiter, Dispatcher
 
 
 class LiteSPIMasterPort:
@@ -27,10 +27,9 @@ class LiteSPISlavePort:
 
 
 class LiteSPICrossbar(Module):
-    def __init__(self, rx_mux, cd):
+    def __init__(self, cd):
         self.cd = cd
-        self.users = OrderedDict()
-        self.rx_mux = rx_mux
+        self.users = []
         self.master = LiteSPIMasterPort()
 
         if cd != "sys":
@@ -44,9 +43,10 @@ class LiteSPICrossbar(Module):
             ]
 
         self.cs = Signal()
-        self.user_cs = {}
+        self.user_cs = []
+        self.user_request = []
 
-    def get_port(self, port_id, cs):
+    def get_port(self, cs, request = None):
         user_port = LiteSPISlavePort()
         internal_port = LiteSPISlavePort()
 
@@ -58,27 +58,39 @@ class LiteSPICrossbar(Module):
 
         self.comb += rx_stream.connect(user_port.source)
 
-        self.users[port_id] = internal_port
-        self.user_cs[port_id] = self.cs.eq(cs)
+        if request is None:
+            request = Signal()
+            self.comb += request.eq(cs)
+
+        self.users.append(internal_port)
+        self.user_cs.append(self.cs.eq(cs))
+        self.user_request.append(request)
 
         return user_port
 
     def do_finalize(self):
-        # TX
-        sinks = [port.sink for port in self.users.values()]
-        self.submodules.arbiter = Arbiter(sinks, self.master.source)
-        # RX
-        sources = [port.source for port in self.users.values()]
-        self.submodules.dispatcher = Dispatcher(self.master.sink,
-                                                sources,
-                                                one_hot=True)
+        self.submodules.rr = RoundRobin(len(self.users))
 
-        cases = {}
-        cases["default"] = self.dispatcher.sel.eq(0)
-        for i, (k, v) in enumerate(self.users.items()):
-            cases[k] = self.dispatcher.sel.eq(2**i)
+        # TX
+        self.submodules.tx_mux = tx_mux = stream.Multiplexer(spi_phy_ctl_layout, len(self.users))
+
+        # RX
+        self.submodules.rx_demux = rx_demux = stream.Demultiplexer(spi_phy_data_layout, len(self.users))
+
+        for i, user in enumerate(self.users):
+            self.comb += [
+                user.sink.connect(getattr(tx_mux, f"sink{i}")),
+                getattr(rx_demux, f"source{i}").connect(user.source),
+            ]
 
         self.comb += [
-            Case(self.rx_mux, cases),
-            Case(self.rx_mux, self.user_cs),
+            self.rr.request.eq(Cat(self.user_request)),
+
+            self.tx_mux.source.connect(self.master.source),
+            self.tx_mux.sel.eq(self.rr.grant),
+
+            self.master.sink.connect(self.rx_demux.sink),
+            self.rx_demux.sel.eq(self.rr.grant),
+
+            Case(self.rr.grant, dict(enumerate(self.user_cs))),
         ]

--- a/litespi/crossbar.py
+++ b/litespi/crossbar.py
@@ -43,7 +43,7 @@ class LiteSPICrossbar(Module):
                 self.master.source.connect(self.tx_cdc.sink),
             ]
 
-        self.cs_n = Signal()
+        self.cs = Signal()
         self.user_cs = {}
 
     def get_port(self, port_id, cs):
@@ -59,7 +59,7 @@ class LiteSPICrossbar(Module):
         self.comb += rx_stream.connect(user_port.source)
 
         self.users[port_id] = internal_port
-        self.user_cs[port_id] = self.cs_n.eq(cs)
+        self.user_cs[port_id] = self.cs.eq(cs)
 
         return user_port
 

--- a/litespi/crossbar.py
+++ b/litespi/crossbar.py
@@ -33,7 +33,7 @@ class LiteSPICrossbar(Module):
         self.rx_mux = rx_mux
         self.master = LiteSPIMasterPort()
 
-        if cd is not "sys":
+        if cd != "sys":
             rx_cdc = stream.AsyncFIFO(spi_phy_data_layout, 32, buffered=True)
             tx_cdc = stream.AsyncFIFO(spi_phy_ctl_layout, 32, buffered=True)
             self.submodules.rx_cdc = ClockDomainsRenamer({"write": "litespi", "read": "sys"})(rx_cdc)

--- a/litespi/phy/generic.py
+++ b/litespi/phy/generic.py
@@ -63,7 +63,7 @@ class LiteSPIPHYCore(Module, AutoCSR, AutoDoc, ModuleDoc):
     sink : Endpoint(spi_phy_ctl_layout), in
         Control stream.
 
-    cs_n : Signal(), in
+    cs : Signal(), in
         Flash CS signal.
 
     clk_divisor : CSRStorage
@@ -99,7 +99,7 @@ class LiteSPIPHYCore(Module, AutoCSR, AutoDoc, ModuleDoc):
     def __init__(self, pads, flash, device, clock_domain, default_divisor):
         self.source              = source = stream.Endpoint(spi_phy_data_layout)
         self.sink                = sink   = stream.Endpoint(spi_phy_ctl_layout)
-        self.cs_n                = Signal()
+        self.cs                  = Signal()
         self._spi_clk_divisor    = spi_clk_divisor = Signal(8)
         self._spi_dummy_bits     = spi_dummy_bits  = Signal(8)
         self._default_dummy_bits = flash.dummy_bits if flash.fast_mode else 0
@@ -166,7 +166,7 @@ class LiteSPIPHYCore(Module, AutoCSR, AutoDoc, ModuleDoc):
             clkgen.div.eq(spi_clk_divisor),
             clkgen.sample_cnt.eq(1),
             clkgen.update_cnt.eq(1),
-            pads.cs_n.eq(self.cs_n),
+            pads.cs_n.eq(~self.cs),
         ]
 
         # I/Os.
@@ -351,7 +351,7 @@ class LiteSPIPHY(Module,AutoDoc, AutoCSR,  ModuleDoc):
     sink : Endpoint(spi_phy_ctl_layout), in
         Control stream from ``LiteSPIPHYCore``.
 
-    cs_n : Signal(), in
+    cs : Signal(), in
         Flash CS signal from ``LiteSPIPHYCore``.
     """
 
@@ -360,7 +360,7 @@ class LiteSPIPHY(Module,AutoDoc, AutoCSR,  ModuleDoc):
 
         self.source = self.phy.source
         self.sink   = self.phy.sink
-        self.cs_n   = self.phy.cs_n
+        self.cs   = self.phy.cs
 
         # # #
 

--- a/litespi/phy/model.py
+++ b/litespi/phy/model.py
@@ -32,7 +32,7 @@ class LiteSPIPHYModel(Module):
     sink : Endpoint(spi_phy_ctl_layout), in
         Control stream.
 
-    cs_n : Signal()
+    cs : Signal()
         Dummy flash CS signal.
     """
     def __init__(self, size, init=None):
@@ -40,7 +40,7 @@ class LiteSPIPHYModel(Module):
         self.sink   = sink   = stream.Endpoint(spi_phy_ctl_layout)
         mem         = Memory(32, size//4, init=init)
         read_addr   = Signal(32)
-        self.cs_n   = Signal()
+        self.cs     = Signal()
 
         read_port   = mem.get_port(async_read=True)
         self.comb  += read_port.adr.eq(read_addr)


### PR DESCRIPTION
This patchset implements #46.

Arbitration is handled with a `request` signal that's by default derived from CS, but overridable for modules that needs to keep uninterrupted control across multiple commands.

To allow the MMIO core to still merge sequential reads into a single command but also allow other cores to use the flash, I've added a timeout for how long it'll keep CS asserted after a finished read. The performance overhead from the 10000-cycle CS delay (see #43) will be addressed in a later PR.

I've also included two patches that cleans up the CS polarity and fixes the remaining erroneous uses of `is not`.

Since the CSR for manual mode control is removed, this PR depends on https://github.com/enjoy-digital/litex/pull/915 also being merged.

Closes #46.