### PR TITLE
phy/generic: Enforce minimum CS inactive time.

### DIFF
--- a/litespi/core/mmap.py
+++ b/litespi/core/mmap.py
@@ -49,7 +49,6 @@ class LiteSPIMMAP(Module):
 
         curr_addr = Signal(32)
         bus_read  = Signal()
-        cs_count  = Signal(16)
         timeout   = Signal(max = MMAP_DEFAULT_TIMEOUT)
 
         # Decode Bus Read Commands.
@@ -62,7 +61,7 @@ class LiteSPIMMAP(Module):
         self.submodules.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
             If(bus_read,
-                NextState("CS-DELAY"),
+                NextState("CMD"),
             )
         )
         fsm.act("CMD",
@@ -107,15 +106,7 @@ class LiteSPIMMAP(Module):
                     NextState("READ-REQ"),
                 # Else we have to initiate another SPI Burst.
                 ).Else(
-                    NextState("CS-DELAY"),
+                    NextState("IDLE"),
                 )
-            )
-        )
-        fsm.act("CS-DELAY",
-            If(cs_count < 10000, # FIXME: Make it configurable.
-                NextValue(cs_count, cs_count + 1),
-            ).Else(
-                NextValue(cs_count, 0),
-                NextState("CMD"),
             )
         )


### PR DESCRIPTION
This patch removes the CS delay from the MMAP module and adds enforcement of a minimum CS inactive time to the PHY instead. This will ensure it is enforced regardless of which module is accessing the flash.

I haven't seen any rationale for why the default should be 10000 cycles, so I've reduced it to 10, which seems plenty for typical flash chips and system frequencies. If the default is not appropriate, it's now also configurable through an argument to the PHY.

In the future we should probably add the minimum time to the module metadata so that the minimum number of cycles can be calculated rather than configured, but that is out of the scope for this PR.

Fixes #43.