### PR TITLE
Support command width of 4 (READ_4_4_4)

### DIFF
--- a/litespi/modules/modules.py
+++ b/litespi/modules/modules.py
@@ -4,6 +4,34 @@ from litespi.ids import SpiNorFlashManufacturerIDs
 
 # Define non-generated SPI NOR chips here
 
+class MX25L12833F(SpiNorFlashModule):
+    """MX25L12833F
+
+    Datasheet: https://www.macronix.com/Lists/Datasheet/Attachments/7447/MX25L12833F,%203V,%20128Mb,%20v1.0.pdf
+    """
+
+    manufacturer_id = SpiNorFlashManufacturerIDs.MACRONIX
+    device_id = 0x2018
+    name = "mx25l12833f"
+
+    total_size  =   16777216   # bytes
+    page_size   =        256   # bytes
+    total_pages =      65536
+
+    supported_opcodes = [
+        SpiNorFlashOpCodes.READ_1_1_1,
+        SpiNorFlashOpCodes.READ_1_1_1_FAST,
+        SpiNorFlashOpCodes.READ_1_1_2,
+        SpiNorFlashOpCodes.READ_1_2_2,
+        SpiNorFlashOpCodes.READ_1_1_4,
+        SpiNorFlashOpCodes.READ_1_4_4,
+        SpiNorFlashOpCodes.READ_4_4_4,
+        SpiNorFlashOpCodes.PP_1_1_1,
+        SpiNorFlashOpCodes.PP_1_4_4,
+    ]
+    dummy_bits = 8
+
+
 class MX25L6406E(SpiNorFlashModule):
     """MX25L6406E
 

--- a/litespi/opcodes.py
+++ b/litespi/opcodes.py
@@ -33,6 +33,7 @@ class SpiNorFlashOpCodes:
     READ_1_2_2         = _Op(0xbb, "Read data bytes (Dual I/O SPI)")
     READ_1_1_4         = _Op(0x6b, "Read data bytes (Quad Output SPI)")
     READ_1_4_4         = _Op(0xeb, "Read data bytes (Quad I/O SPI)") # Fast Read Quad
+    READ_4_4_4         = _Op(0xeb, "Read data bytes (Quad I/O QPI)")
     READ_1_1_8         = _Op(0x8b, "Read data bytes (Octal Output SPI)")
     READ_1_8_8         = _Op(0xcb, "Read data bytes (Octal I/O SPI)")
 


### PR DESCRIPTION
Currently LiteSPI can't send commands using 4 lines (e.g. in QPI mode). This PR enables that and adds an SPI flash chip that supports the new `READ_4_4_4` opcode.