### PR TITLE
Allow multiple chip selects in crossbar

### DIFF
--- a/test/test_crossbar.py
+++ b/test/test_crossbar.py
@@ -61,3 +61,62 @@ class TestCrossbar(unittest.TestCase):
             self.assertEqual((yield port_c.sink.ready), False)
 
         run_simulation(dut, process())
+
+    def test_cs_multiple(self):
+        dut = LiteSPICrossbar('sys')
+        dut.comb += dut.master.source.ready.eq(True)
+
+        out1 = dut.add_output_cs()
+        out2 = dut.add_output_cs()
+        out3 = dut.add_output_cs()
+
+        all_out = Cat(out1, out2, out3)
+
+        a_cs = Signal(2)
+        b_cs = Signal()
+        c_cs = Signal()
+        d_cs = Signal(2)
+
+        port_a = dut.get_port(a_cs, output_cs=Cat(out1, out2))
+        port_b = dut.get_port(b_cs)  # legacy (dut.cs)
+        port_c = dut.get_port(c_cs, output_cs=out3)  # explicit single
+        port_d = dut.get_port(d_cs, output_cs=Cat(out1, out2))
+
+        def process():
+            self.assertEqual((yield all_out), 0x0)
+
+            yield a_cs.eq(0b01)  # select out1
+            yield
+
+            self.assertEqual((yield all_out), 0x1)
+            self.assertEqual((yield port_a.sink.ready), True)
+            self.assertEqual((yield port_b.sink.ready), False)
+            self.assertEqual((yield port_c.sink.ready), False)
+            self.assertEqual((yield port_d.sink.ready), False)
+
+            yield a_cs.eq(0b10)  # select out2
+            yield
+
+            self.assertEqual((yield all_out), 0x2)
+            self.assertEqual((yield port_a.sink.ready), True)
+            self.assertEqual((yield port_b.sink.ready), False)
+            self.assertEqual((yield port_c.sink.ready), False)
+            self.assertEqual((yield port_d.sink.ready), False)
+
+            yield a_cs.eq(0)
+            yield d_cs.eq(0b10)  # select out2
+            yield  # beat to allow cs to fall
+            yield
+
+            self.assertEqual((yield all_out), 0x2)
+            self.assertEqual((yield port_a.sink.ready), False)
+            self.assertEqual((yield port_b.sink.ready), False)
+            self.assertEqual((yield port_c.sink.ready), False)
+            self.assertEqual((yield port_d.sink.ready), True)
+
+        run_simulation(dut, process(), vcd_name='xbar.vcd')
+
+    def test_invalid_output_cs(self):
+        dut = LiteSPICrossbar('sys')
+        with self.assertRaises(AssertionError):
+            dut.get_port(Signal(1), output_cs=Signal(2))

--- a/test/test_crossbar.py
+++ b/test/test_crossbar.py
@@ -1,0 +1,63 @@
+#
+# This file is part of LiteSPI
+#
+# Copyright (c) 2021 George Hilliard <thirtythreeforty@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+
+from litespi.crossbar import LiteSPICrossbar
+from litespi.common import *
+
+
+class TestCrossbar(unittest.TestCase):
+    def test_cs_mux(self):
+        dut = LiteSPICrossbar('sys')
+        dut.comb += dut.master.source.ready.eq(True)
+
+        a_cs, b_cs, c_cs = Signal(), Signal(), Signal()
+        port_a = dut.get_port(a_cs)
+        port_b = dut.get_port(b_cs)
+        port_c = dut.get_port(c_cs)
+
+        def process():
+            yield
+
+            self.assertEqual((yield dut.cs), 0)
+
+            yield a_cs.eq(True)
+            yield
+
+            self.assertEqual((yield dut.cs), 1)
+            self.assertEqual((yield port_a.sink.ready), True)
+            self.assertEqual((yield port_b.sink.ready), False)
+            self.assertEqual((yield port_c.sink.ready), False)
+
+            yield a_cs.eq(False)
+            yield b_cs.eq(True)
+            yield # beat to allow cs to fall
+
+            self.assertEqual((yield dut.cs), 0)
+
+            yield
+            self.assertEqual((yield dut.cs), 1)
+            self.assertEqual((yield port_a.sink.ready), False)
+            self.assertEqual((yield port_b.sink.ready), True)
+            self.assertEqual((yield port_c.sink.ready), False)
+
+            yield a_cs.eq(True)
+            yield b_cs.eq(False)
+            yield # beat to allow cs to fall
+
+            self.assertEqual((yield dut.cs), 0)
+
+            yield
+
+            self.assertEqual((yield dut.cs), 1)
+            self.assertEqual((yield port_a.sink.ready), True)
+            self.assertEqual((yield port_b.sink.ready), False)
+            self.assertEqual((yield port_c.sink.ready), False)
+
+        run_simulation(dut, process())

--- a/test/test_spi_master.py
+++ b/test/test_spi_master.py
@@ -1,0 +1,55 @@
+#
+# This file is part of LiteSPI
+#
+# Copyright (c) 2021 George Hilliard <thirtythreeforty@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+
+from litespi.core.master import LiteSPIMaster
+from litespi.common import *
+
+
+class TestSPIMaster(unittest.TestCase):
+    def test_spi_txrx_loopback(self):
+        dut = LiteSPIMaster()
+        dut.comb += dut.source.ready.eq(dut.sink.ready)
+        dut.comb += dut.sink.valid.eq(dut.source.valid)
+        dut.comb += dut.sink.data.eq(dut.source.data)
+
+        dut.comb += dut._rxtx.we.eq(dut._status.fields.rx_ready)
+
+        write_seq = list(range(0x20))
+        read_seq = []
+
+        def do_write():
+            write_iter = iter(write_seq)
+            byte = next(write_iter)
+            cycles = 0
+
+            while write_seq != read_seq:
+                # write to queue
+                if (yield dut._status.fields.tx_ready) == 1 and byte is not None:
+                    yield dut._rxtx.re.eq(1)
+                    yield dut._rxtx.r.eq(byte)
+                    try:
+                        byte = next(write_iter)
+                    except StopIteration:
+                        byte = None
+                else:
+                    yield dut._rxtx.re.eq(0)
+
+                # read from queue, .we is comb connected to .rx_ready
+                if (yield dut._status.fields.rx_ready) == 1:
+                    read_seq.append((yield dut._rxtx.w))
+
+                yield
+
+                cycles += 1
+                if cycles == 40:
+                    return
+
+        run_simulation(dut, do_write())
+        self.assertListEqual(write_seq, read_seq)


### PR DESCRIPTION
This PR adds support for forwarding one or more chip selects from a client out to multiple output CS lines, while still arbitrating use of the shared MOSI/MISO/CLK lines and PHY.

Since each client may care about a different physical CS line or set of CS lines, these are passed in to `get_port()`:

```py
  output1 = xbar.add_output_cs()
  output2 = xbar.add_output_cs()
  user_cs = Signal(2)
  port = xbar.get_port(user_cs, output_cs=Cat(output1, output2))
```

(The default is to continue to use `self.cs` to preserve existing behavior.)

My use case is that I will have an autonomous (edge triggered) SPI master that reflects status signals from RTL onto GPIOs on a SPI expander, and a memory-mapped SPI flash.  If this approach is good, I'm open to how you think this could be cleanly extended up into the chipselect register exposed by SPIMaster.

I also added unit tests for the existing behavior of the crossbar and master.  Feedback is desired here because I don't feel like they're super idiomatic, but I wanted something in place before I really started making changes.