### PR TITLE
Litespi - using the ODDR/IDDR, simplifying models 

### DIFF
--- a/litespi/__init__.py
+++ b/litespi/__init__.py
@@ -56,12 +56,9 @@ class LiteSPI(Module, AutoCSR, AutoDoc, ModuleDoc):
         Wishbone interface for memory-mapped flash access.
     """
 
-    def __init__(self, phy, clk_freq, clock_domain="sys",
+    def __init__(self, phy, clock_domain="sys",
         with_mmap=True, mmap_endianness="big",
         with_master=True, master_tx_fifo_depth=1, master_rx_fifo_depth=1):
-        self.sys_clk_freq = sys_clk_freq = CSRStatus(32)
-
-        self.comb += sys_clk_freq.status.eq(clk_freq)
 
         self.submodules.crossbar = crossbar = LiteSPICrossbar(clock_domain)
         self.comb += phy.cs.eq(crossbar.cs)

--- a/litespi/__init__.py
+++ b/litespi/__init__.py
@@ -67,7 +67,8 @@ class LiteSPI(Module, AutoCSR, AutoDoc, ModuleDoc):
         self.comb += phy.cs.eq(crossbar.cs)
 
         if with_mmap:
-            self.submodules.mmap = mmap = LiteSPIMMAP(endianness=mmap_endianness)
+            self.submodules.mmap = mmap = LiteSPIMMAP(flash=phy.flash,
+                                                      endianness=mmap_endianness)
             port_mmap = crossbar.get_port(mmap.cs)
             self.bus = mmap.bus
             self.comb += [

--- a/litespi/__init__.py
+++ b/litespi/__init__.py
@@ -72,6 +72,8 @@ class LiteSPI(Module, AutoCSR, AutoDoc, ModuleDoc):
                 port_mmap.source.connect(mmap.sink),
                 mmap.source.connect(port_mmap.sink),
             ]
+            if hasattr(phy, "dummy_bits"):
+                self.comb += phy.dummy_bits.eq(mmap._spi_dummy_bits)
         if with_master:
             self.submodules.master = master = LiteSPIMaster(
                 tx_fifo_depth = master_tx_fifo_depth,

--- a/litespi/clkgen.py
+++ b/litespi/clkgen.py
@@ -8,7 +8,29 @@ from migen import *
 
 from litex.soc.integration.doc import AutoDoc, ModuleDoc
 
-from litex.build.io import DDROutput
+from litex.build.io import SDROutput, DDROutput
+
+class DDRLiteSPIClkGen(Module, AutoDoc, ModuleDoc):
+    """SPI Clock generator
+
+    The ``DDRLiteSPIClkGen`` class provides a generic SPI clock generator.
+
+    The class can be combined with DDR PHY Core.
+
+    Parameters
+    ----------
+    pads : Object
+        SPI pads description.
+
+    Attributes
+    ----------
+    en : Signal(), in
+        Clock enable input, output clock will be generated if set to 1, 0 resets the core.
+    """
+    def __init__(self, pads):
+        self.en         = en         = Signal()
+
+        self.specials += DDROutput(i1=en, i2=0, o=pads.clk)
 
 
 class LiteSPIClkGen(Module, AutoDoc, ModuleDoc):
@@ -59,11 +81,47 @@ class LiteSPIClkGen(Module, AutoDoc, ModuleDoc):
         Controls generation of the ``update`` signal.
     """
     def __init__(self, pads, device, cnt_width=8, with_ddr=False):
+        self.div        = div        = Signal(cnt_width)
+        self.sample_cnt = sample_cnt = Signal(cnt_width)
+        self.update_cnt = update_cnt = Signal(cnt_width)
+        self.posedge    = posedge    = Signal()
+        self.negedge    = negedge    = Signal()
+        self.sample     = sample     = Signal()
+        self.update     = update     = Signal()
         self.en         = en         = Signal()
-        self.active     = active     = Signal()
+        cnt             = Signal(cnt_width)
         en_int          = Signal()
+        clk             = Signal()
 
-        self.comb += self.active.eq(en | en_int)
+        self.comb += [
+            posedge.eq(en & ~clk & (cnt == div)),
+            negedge.eq(en & clk & (cnt == div)),
+            sample.eq(cnt == sample_cnt),
+            update.eq(cnt == update_cnt),
+        ]
+
+        # Delayed edge to account for IO register delays.
+        self.posedge_reg  = posedge_reg  = Signal()
+        self.posedge_reg2 = posedge_reg2 = Signal()
+
+        self.sync += [
+            posedge_reg.eq(posedge),
+            posedge_reg2.eq(posedge_reg),
+        ]
+
+        self.sync += [
+            If(en | en_int,
+                If(cnt < div,
+                    cnt.eq(cnt+1),
+                ).Else(
+                    cnt.eq(0),
+                    clk.eq(~clk),
+                )
+            ).Else(
+                clk.eq(0),
+                cnt.eq(0),
+            )
+        ]
 
         if not hasattr(pads, "clk"):
             # Clock output needs to be registered like an SDROutput.
@@ -94,5 +152,4 @@ class LiteSPIClkGen(Module, AutoDoc, ModuleDoc):
             else:
                 raise NotImplementedError
         else:
-            self.specials += DDROutput(i1=active, i2=0, o=pads.clk)
-
+            self.specials += SDROutput(i=clk, o=pads.clk)

--- a/litespi/core/mmap.py
+++ b/litespi/core/mmap.py
@@ -9,11 +9,25 @@ from migen.genlib.misc import WaitTimer
 
 from litex.soc.interconnect import wishbone, stream
 from litex.gen.common import reverse_bytes
+from litex.soc.interconnect.csr import *
 
 from litespi.common import *
+from migen.genlib.cdc import MultiReg
 
+cmd_oe_mask  = {
+    1: 0b00000001,
+    2: 0b00000011,
+    4: 0b00001111,
+    8: 0b11111111,
+}
+addr_oe_mask = {
+    1: 0b00000001,
+    2: 0b00000011,
+    4: 0b00001111,
+    8: 0b11111111,
+}
 
-class LiteSPIMMAP(Module):
+class LiteSPIMMAP(Module, AutoCSR):
     """Memory-mapped SPI Flash controller.
 
     The ``LiteSPIMMAP`` class provides a Wishbone slave that must be connected to a LiteSPI PHY.
@@ -38,21 +52,41 @@ class LiteSPIMMAP(Module):
 
     cs : Signal(), out
         CS signal for the flash chip, should be connected to cs signal of the PHY.
+
+    dummy_bits : CSRStorage
+        Register which hold a number of dummy bits to send during transmission.
     """
-    def __init__(self, endianness="big"):
+    def __init__(self, flash, clock_domain="sys", endianness="big"):
         self.source = source = stream.Endpoint(spi_core2phy_layout)
         self.sink   = sink   = stream.Endpoint(spi_phy2core_layout)
         self.bus    = bus    = wishbone.Interface()
         self.cs     = cs     = Signal()
-
-        # # #
-
 
         # Burst Control.
         burst_cs      = Signal()
         burst_adr     = Signal(len(bus.adr), reset_less=True)
         burst_timeout = WaitTimer(MMAP_DEFAULT_TIMEOUT)
         self.submodules += burst_timeout
+
+        cmd_bits = 8
+        data_bits = 32
+
+        if flash.cmd_width == 1:
+            self._default_dummy_bits = flash.dummy_bits if flash.fast_mode else 0
+        elif flash.cmd_width == 4:
+            self._default_dummy_bits = flash.dummy_bits * 3 if flash.fast_mode else 0
+        else:
+            raise NotImplementedError(f'Command width of {flash.cmd_width} bits is currently not supported!')
+
+        self.dummy_bits          = dummy_bits      = CSRStorage(8, reset=self._default_dummy_bits)
+
+        self._spi_dummy_bits     = spi_dummy_bits  = Signal(8)
+        if clock_domain != "sys":
+            self.specials += MultiReg(dummy_bits.storage,  spi_dummy_bits,  "litespi")
+        else:
+            self.comb += spi_dummy_bits.eq(dummy_bits.storage)
+
+        dummy = Signal(data_bits, reset=0xdead)
 
         # FSM.
         self.submodules.fsm = fsm = FSM(reset_state="IDLE")
@@ -74,26 +108,93 @@ class LiteSPIMMAP(Module):
                 )
             )
         )
+
         fsm.act("BURST-CMD",
             cs.eq(1),
             source.valid.eq(1),
-            source.cmd.eq(CMD),
-            source.data.eq(Cat(Signal(2), bus.adr)), # Words to Bytes.
+            source.cmd.eq(USER),
+            source.data.eq(flash.read_opcode.code), # send command.
+            source.len.eq(cmd_bits),
+            source.width.eq(flash.cmd_width),
+            source.mask.eq(cmd_oe_mask[flash.cmd_width]),
+            NextValue(burst_adr, bus.adr),
+            If(source.ready,
+                NextState("CMD-RET"),
+            )
+        )
+
+        fsm.act("CMD-RET",
+            cs.eq(1),
+            sink.ready.eq(1),
+            If(sink.valid,
+                NextState("BURST-ADDR"),
+            )
+        )
+
+        fsm.act("BURST-ADDR",
+            cs.eq(1),
+            source.valid.eq(1),
+            source.cmd.eq(USER),
+            source.width.eq(flash.addr_width),
+            source.mask.eq(addr_oe_mask[flash.addr_width]),
+            source.data.eq(Cat(Signal(2), bus.adr)), # send address.
+            source.len.eq(flash.addr_bits),
             NextValue(burst_cs, 1),
             NextValue(burst_adr, bus.adr),
             If(source.ready,
+                NextState("ADDR-RET"),
+            )
+        )
+
+        fsm.act("ADDR-RET",
+            cs.eq(1),
+            sink.ready.eq(1),
+            If(sink.valid,
+                If(spi_dummy_bits == 0,
+                    NextState("BURST-REQ"),
+                ).Else(
+                    NextState("DUMMY"),
+                )
+            )
+        )
+
+        fsm.act("DUMMY",
+            cs.eq(1),
+            source.valid.eq(1),
+            source.cmd.eq(USER),
+            source.width.eq(flash.addr_width),
+            source.mask.eq(addr_oe_mask[flash.addr_width]),
+            source.data.eq(dummy),
+            source.len.eq(spi_dummy_bits),
+            NextValue(burst_cs, 1),
+            NextValue(burst_adr, bus.adr),
+            If(source.ready,
+                NextState("DUMMY-RET"),
+            )
+        )
+
+        fsm.act("DUMMY-RET",
+            cs.eq(1),
+            sink.ready.eq(1),
+            If(sink.valid,
                 NextState("BURST-REQ"),
             )
         )
+
         fsm.act("BURST-REQ",
             cs.eq(1),
             source.valid.eq(1),
-            source.cmd.eq(READ),
+            sink.ready.eq(1),
             source.last.eq(1),
+            source.cmd.eq(USER),
+            source.width.eq(flash.bus_width),
+            source.len.eq(data_bits),
+            source.mask.eq(0),
             If(source.ready,
                 NextState("BURST-DAT"),
             )
         )
+
         fsm.act("BURST-DAT",
             cs.eq(1),
             sink.ready.eq(1),

--- a/litespi/crossbar.py
+++ b/litespi/crossbar.py
@@ -31,12 +31,11 @@ class LiteSPICrossbar(Module):
         self.cd     = cd
         self.users  = []
         self.master = LiteSPIMasterPort()
-
         if cd != "sys":
             rx_cdc = stream.AsyncFIFO(spi_phy2core_layout, 32, buffered=True)
             tx_cdc = stream.AsyncFIFO(spi_core2phy_layout, 32, buffered=True)
-            self.submodules.rx_cdc = ClockDomainsRenamer({"write": "litespi", "read": "sys"})(rx_cdc)
-            self.submodules.tx_cdc = ClockDomainsRenamer({"write": "sys", "read": "litespi"})(tx_cdc)
+            self.submodules.rx_cdc = ClockDomainsRenamer({"write": cd, "read": "sys"})(rx_cdc)
+            self.submodules.tx_cdc = ClockDomainsRenamer({"write": "sys", "read": cd})(tx_cdc)
             self.comb += [
                 self.rx_cdc.source.connect(self.master.sink),
                 self.master.source.connect(self.tx_cdc.sink),

--- a/litespi/phy/ddr_generic.py
+++ b/litespi/phy/ddr_generic.py
@@ -1,0 +1,191 @@
+#
+# This file is part of LiteSPI
+#
+# Copyright (c) 2020 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+from migen.genlib.cdc import MultiReg
+from migen.genlib.misc import WaitTimer
+
+from litespi.common import *
+from litespi.clkgen import DDRLiteSPIClkGen
+
+from litex.soc.interconnect import stream
+from litex.soc.interconnect.csr import *
+
+from litex.build.io import DDRTristate
+
+from litex.soc.integration.doc import AutoDoc, ModuleDoc
+
+
+# LiteSPI PHY DDR Core ---------------------------------------------------------------------------------
+
+class DDRLiteSPIPHYCore(Module, AutoCSR, AutoDoc, ModuleDoc):
+    """LiteSPI PHY DDR instantiator
+
+    The ``DDRLiteSPIPHYCore`` class provides a generic PHY that can be connected to the ``LiteSPICore``.
+
+    It supports single/dual/quad/octal output reads from the flash chips.
+
+    You can use this class only with devices that supports the DDR primitives.
+
+    The following diagram shows how each clock configuration option relates to outputs and input sampling in DDR mode:
+
+    .. wavedrom:: ../../doc/ddr-timing-diagram.json
+
+    Parameters
+    ----------
+    pads : Object
+        SPI pads description.
+
+    flash : SpiNorFlashModule
+        SpiNorFlashModule configuration object.
+
+    Attributes
+    ----------
+    source : Endpoint(spi_phy2core_layout), out
+        Data stream.
+
+    sink : Endpoint(spi_core2phy_layout), in
+        Control stream.
+
+    cs : Signal(), in
+        Flash CS signal.
+    """
+    def __init__(self, pads, flash, cs_delay):
+        self.source              = source = stream.Endpoint(spi_phy2core_layout)
+        self.sink                = sink   = stream.Endpoint(spi_core2phy_layout)
+        self.cs                  = Signal()
+
+        if hasattr(pads, "miso"):
+            bus_width = 1
+            pads.dq   = [pads.mosi, pads.miso]
+        else:
+            bus_width = len(pads.dq)
+
+        assert bus_width in [1, 2, 4, 8]
+
+        # Check if number of pads matches configured mode.
+        assert flash.check_bus_width(bus_width)
+
+        self.addr_bits  = addr_bits  = flash.addr_bits
+        self.ddr        = ddr        = flash.ddr
+
+        assert not ddr
+
+        # Clock Generator.
+        self.submodules.clkgen = clkgen = DDRLiteSPIClkGen(pads)
+
+        # CS control.
+        cs_timer = WaitTimer(cs_delay + 1) # Ensure cs_delay cycles between XFers.
+        cs_out   = Signal()
+        self.submodules += cs_timer
+        self.comb += cs_timer.wait.eq(self.cs)
+        self.comb += cs_out.eq(cs_timer.done)
+        self.comb += pads.cs_n.eq(~cs_out)
+
+        # I/Os.
+        data_bits = 32
+
+        dq_o1  = Signal(len(pads.dq))
+        dq_o2  = Signal(len(pads.dq))
+        dq_i1  = Signal(len(pads.dq))
+        dq_i2  = Signal(len(pads.dq))
+        dq_oe1 = Signal(len(pads.dq))
+        dq_oe2 = Signal(len(pads.dq))
+
+        for i in range(len(pads.dq)):
+            self.specials += DDRTristate(
+                io  = pads.dq[i],
+                o1  = dq_o1[i],
+                o2  = dq_o2[i],
+                oe1 = dq_oe1[i],
+                oe2 = dq_oe2[i],
+                i1  = dq_i1[i],
+                i2  = dq_i2[i]
+            )
+
+        # FSM.
+        shift_cnt = Signal(8, reset_less=True)
+        addr      = Signal(addr_bits if not ddr else addr_bits + addr_width, reset_less=True)
+        data      = Signal(data_bits, reset_less=True)
+
+        usr_dout  = Signal(len(sink.data),  reset_less=True)
+        usr_din   = Signal(len(sink.data),  reset_less=True)
+        usr_len   = Signal(len(sink.len),   reset_less=True)
+        usr_width = Signal(len(sink.width), reset_less=True)
+        usr_mask  = Signal(len(sink.mask),  reset_less=True)
+
+        clk_en = Signal()
+
+        self.comb += self.clkgen.en.eq(clk_en)
+
+        din_width_cases = {1: [
+                 NextValue(usr_din, Cat(dq_o1[1], usr_din)),
+            ]
+        }
+        for i in [2, 4, 8]:
+            din_width_cases[i] = [
+                NextValue(usr_din, Cat(dq_o1[0:i], usr_din))
+            ]
+
+        dout_width_cases = {}
+        for i in [1, 2, 4, 8]:
+            dout_width_cases[i] = [
+                dq_i2.eq(usr_dout[-i:]),
+                NextValue(dq_i1, dq_i2)
+            ]
+
+        self.submodules.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            sink.ready.eq(cs_out),
+            NextValue(clk_en, 0),
+            If(sink.valid & sink.ready,
+                Case(sink.cmd, {
+                    USER: [
+                        NextValue(usr_dout,  sink.data << (32-sink.len)),
+                        NextValue(usr_din,   0),
+                        NextValue(usr_len,   sink.len),
+                        NextValue(usr_width, sink.width),
+                        NextValue(usr_mask,  sink.mask),
+                        Case(sink.width, dout_width_cases),
+                        NextState("USER")
+                    ]
+                })
+            )
+        )
+
+        fsm.act("USER",
+            NextValue(clk_en, 1),
+            dq_oe2.eq(usr_mask),
+            NextValue(dq_oe1, dq_oe2),
+
+            Case(usr_width, dout_width_cases),
+            Case(usr_width, din_width_cases),
+            NextValue(usr_dout, usr_dout<<usr_width),
+
+            NextValue(shift_cnt, shift_cnt+usr_width),
+            If(shift_cnt == (usr_len-usr_width),
+                NextValue(shift_cnt, 0),
+                NextState("USER_END"),
+            ),
+        )
+        fsm.act("USER_END",
+            NextValue(clk_en, 0),
+            Case(usr_width, din_width_cases),
+            NextValue(dq_i1, 0),
+            NextValue(shift_cnt, shift_cnt+usr_width),
+            If(shift_cnt == (2*usr_width),
+                NextValue(shift_cnt, 0),
+                NextState("SEND_USER_DATA"),
+            ),
+        )
+        fsm.act("SEND_USER_DATA",
+            source.valid.eq(1),
+            source.last.eq(1),
+            source.data.eq(usr_din),
+            If(source.ready,
+                NextState("IDLE"),
+            )
+        )

--- a/litespi/phy/generic.py
+++ b/litespi/phy/generic.py
@@ -9,188 +9,11 @@ from migen.genlib.cdc import MultiReg
 from migen.genlib.misc import WaitTimer
 
 from litespi.common import *
-from litespi.clkgen import LiteSPIClkGen
 
-from litex.soc.interconnect import stream
 from litex.soc.interconnect.csr import *
 
-from litex.build.io import DDRTristate
 
 from litex.soc.integration.doc import AutoDoc, ModuleDoc
-
-# Output enable masks for the tri-state buffers, data mode mask is not included as oe pins default to 0
-
-# LiteSPI PHY Core ---------------------------------------------------------------------------------
-
-class LiteSPIPHYCore(Module, AutoCSR, AutoDoc, ModuleDoc):
-    """LiteSPI PHY instantiator
-
-    The ``LiteSPIPHYCore`` class provides a generic PHY that can be connected to the ``LiteSPICore``.
-
-    It supports single/dual/quad/octal output reads from the flash chips.
-
-    The following diagram shows how each clock configuration option relates to outputs and input sampling in DDR mode:
-
-    .. wavedrom:: ../../doc/ddr-timing-diagram.json
-
-    Parameters
-    ----------
-    pads : Object
-        SPI pads description.
-
-    flash : SpiNorFlashModule
-        SpiNorFlashModule configuration object.
-
-    device : str
-        Device type for use by the ``LiteSPIClkGen``.
-
-    Attributes
-    ----------
-    source : Endpoint(spi_phy2core_layout), out
-        Data stream.
-
-    sink : Endpoint(spi_core2phy_layout), in
-        Control stream.
-
-    cs : Signal(), in
-        Flash CS signal.
-    """
-    def __init__(self, pads, flash, device, clock_domain, cs_delay):
-        self.source              = source = stream.Endpoint(spi_phy2core_layout)
-        self.sink                = sink   = stream.Endpoint(spi_core2phy_layout)
-        self.cs                  = Signal()
-
-        if hasattr(pads, "miso"):
-            bus_width = 1
-            pads.dq   = [pads.mosi, pads.miso]
-        else:
-            bus_width = len(pads.dq)
-
-        assert bus_width in [1, 2, 4, 8]
-
-        # Check if number of pads matches configured mode.
-        assert flash.check_bus_width(bus_width)
-
-        self.addr_bits  = addr_bits  = flash.addr_bits
-        self.ddr        = ddr        = flash.ddr
-
-        assert not ddr
-
-        # Clock Generator.
-        self.submodules.clkgen = clkgen = LiteSPIClkGen(pads, device, with_ddr=ddr)
-
-        # CS control.
-        cs_timer = WaitTimer(cs_delay + 1) # Ensure cs_delay cycles between XFers.
-        cs_out   = Signal()
-        self.submodules += cs_timer
-        self.comb += cs_timer.wait.eq(self.cs)
-        self.comb += cs_out.eq(cs_timer.done)
-        self.comb += pads.cs_n.eq(~cs_out)
-
-        # I/Os.
-        data_bits = 32
-
-        dq_o1  = Signal(len(pads.dq))
-        dq_o2  = Signal(len(pads.dq))
-        dq_i1  = Signal(len(pads.dq))
-        dq_i2  = Signal(len(pads.dq))
-        dq_oe1 = Signal(len(pads.dq))
-        dq_oe2 = Signal(len(pads.dq))
-
-        for i in range(len(pads.dq)):
-            self.specials += DDRTristate(
-                io  = pads.dq[i],
-                o1  = dq_o1[i],
-                o2  = dq_o2[i],
-                oe1 = dq_oe1[i],
-                oe2 = dq_oe2[i],
-                i1  = dq_i1[i],
-                i2  = dq_i2[i]
-            )
-
-        # FSM.
-        shift_cnt = Signal(8, reset_less=True)
-        addr      = Signal(addr_bits if not ddr else addr_bits + addr_width, reset_less=True)
-        data      = Signal(data_bits, reset_less=True)
-
-        usr_dout  = Signal(len(sink.data),  reset_less=True)
-        usr_din   = Signal(len(sink.data),  reset_less=True)
-        usr_len   = Signal(len(sink.len),   reset_less=True)
-        usr_width = Signal(len(sink.width), reset_less=True)
-        usr_mask  = Signal(len(sink.mask),  reset_less=True)
-
-        clk_en = Signal()
-
-        self.comb += self.clkgen.en.eq(clk_en)
-
-        din_width_cases = {1: [
-                 NextValue(usr_din, Cat(dq_o1[1], usr_din)),
-            ]
-        }
-        for i in [2, 4, 8]:
-            din_width_cases[i] = [
-                NextValue(usr_din, Cat(dq_o1[0:i], usr_din))
-            ]
-
-        dout_width_cases = {}
-        for i in [1, 2, 4, 8]:
-            dout_width_cases[i] = [
-                dq_i2.eq(usr_dout[-i:]),
-                NextValue(dq_i1, dq_i2)
-            ]
-
-        self.submodules.fsm = fsm = FSM(reset_state="IDLE")
-        fsm.act("IDLE",
-            sink.ready.eq(cs_out),
-            NextValue(clk_en, 0),
-            If(sink.valid & sink.ready,
-                Case(sink.cmd, {
-                    USER: [
-                        NextValue(usr_dout,  sink.data << (32-sink.len)),
-                        NextValue(usr_din,   0),
-                        NextValue(usr_len,   sink.len),
-                        NextValue(usr_width, sink.width),
-                        NextValue(usr_mask,  sink.mask),
-                        Case(sink.width, dout_width_cases),
-                        NextState("USER")
-                    ]
-                })
-            )
-        )
-
-        fsm.act("USER",
-            NextValue(clk_en, 1),
-            dq_oe2.eq(usr_mask),
-            NextValue(dq_oe1, dq_oe2),
-
-            Case(usr_width, dout_width_cases),
-            Case(usr_width, din_width_cases),
-            NextValue(usr_dout, usr_dout<<usr_width),
-
-            NextValue(shift_cnt, shift_cnt+usr_width),
-            If(shift_cnt == (usr_len-usr_width),
-                NextValue(shift_cnt, 0),
-                NextState("USER_END"),
-            ),
-        )
-        fsm.act("USER_END",
-            NextValue(clk_en, 0),
-            Case(usr_width, din_width_cases),
-            NextValue(dq_i1, 0),
-            NextValue(shift_cnt, shift_cnt+usr_width),
-            If(shift_cnt == (2*usr_width),
-                NextValue(shift_cnt, 0),
-                NextState("SEND_USER_DATA"),
-            ),
-        )
-        fsm.act("SEND_USER_DATA",
-            source.valid.eq(1),
-            source.last.eq(1),
-            source.data.eq(usr_din),
-            If(source.ready,
-                NextState("IDLE"),
-            )
-        )
 
 # LiteSPI PHY --------------------------------------------------------------------------------------
 
@@ -214,6 +37,9 @@ class LiteSPIPHY(Module,AutoDoc, AutoCSR,  ModuleDoc):
     clock_domain : str
         Name of LiteSPI clock domain.
 
+    default_divisor : int (only legacy mode)
+        Default frequency divisor for clkgen.
+
     Attributes
     ----------
     source : Endpoint(spi_phy2core_layout), out
@@ -226,8 +52,14 @@ class LiteSPIPHY(Module,AutoDoc, AutoCSR,  ModuleDoc):
         Flash CS signal from ``LiteSPIPHYCore``.
     """
 
-    def __init__(self, pads, flash, device="xc7", clock_domain="sys", cs_delay=10):
-        self.phy = LiteSPIPHYCore(pads, flash, device, clock_domain, cs_delay)
+    def __init__(self, pads, flash, device="xc7", clock_domain="sys", default_divisor=9, cs_delay=10, legacy=True):
+        if legacy:
+            from litespi.phy.legacy_generic import LiteSPIPHYCore
+            self.phy = LiteSPIPHYCore(pads, flash, device, clock_domain, default_divisor, cs_delay)
+        else:
+            from litespi.phy.ddr_generic import DDRLiteSPIPHYCore
+            self.phy = DDRLiteSPIPHYCore(pads, flash, cs_delay)
+
         self.flash = flash
 
         self.source = self.phy.source

--- a/litespi/phy/legacy_generic.py
+++ b/litespi/phy/legacy_generic.py
@@ -1,0 +1,223 @@
+#
+# This file is part of LiteSPI
+#
+# Copyright (c) 2020 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+from migen.genlib.cdc import MultiReg
+from migen.genlib.misc import WaitTimer
+
+from litespi.common import *
+from litespi.clkgen import LiteSPIClkGen
+
+from litex.soc.interconnect import stream
+from litex.soc.interconnect.csr import *
+
+from litex.build.io import SDRTristate
+
+from litex.soc.integration.doc import AutoDoc, ModuleDoc
+
+# LiteSPI PHY Core ---------------------------------------------------------------------------------
+
+class LiteSPIPHYCore(Module, AutoCSR, AutoDoc, ModuleDoc):
+    """LiteSPI PHY instantiator
+
+    The ``LiteSPIPHYCore`` class provides a generic PHY that can be connected to the ``LiteSPICore``.
+
+    It supports single/dual/quad/octal output reads from the flash chips.
+
+    The following diagram shows how each clock configuration option relates to outputs and input sampling in DDR mode:
+
+    .. wavedrom:: ../../doc/ddr-timing-diagram.json
+
+    Parameters
+    ----------
+    pads : Object
+        SPI pads description.
+
+    flash : SpiNorFlashModule
+        SpiNorFlashModule configuration object.
+
+    device : str
+        Device type for use by the ``LiteSPIClkGen``.
+
+    default_divisor : int
+        Default frequency divisor for clkgen.
+
+    Attributes
+    ----------
+    source : Endpoint(spi_phy2core_layout), out
+        Data stream.
+
+    sink : Endpoint(spi_core2phy_layout), in
+        Control stream.
+
+    cs : Signal(), in
+        Flash CS signal.
+
+    clk_divisor : CSRStorage
+        Register which holds a clock divisor value applied to clkgen.
+    """
+    def __init__(self, pads, flash, device, clock_domain, default_divisor, cs_delay):
+        self.source              = source = stream.Endpoint(spi_phy2core_layout)
+        self.sink                = sink   = stream.Endpoint(spi_core2phy_layout)
+        self.cs                  = Signal()
+        self._spi_clk_divisor    = spi_clk_divisor = Signal(8)
+
+        self._default_divisor    = default_divisor
+
+        self.clk_divisor         = clk_divisor     = CSRStorage(8, reset=self._default_divisor)
+
+        # # #
+
+        if clock_domain != "sys":
+            self.specials += MultiReg(clk_divisor.storage, spi_clk_divisor, "litespi")
+        else:
+            self.comb += spi_clk_divisor.eq(clk_divisor.storage)
+        if hasattr(pads, "miso"):
+            bus_width = 1
+            pads.dq   = [pads.mosi, pads.miso]
+        else:
+            bus_width = len(pads.dq)
+
+        assert bus_width in [1, 2, 4, 8]
+
+        # Check if number of pads matches configured mode.
+        assert flash.check_bus_width(bus_width)
+
+        self.addr_bits  = addr_bits  = flash.addr_bits
+        self.cmd_width  = cmd_width  = flash.cmd_width
+        self.addr_width = addr_width = flash.addr_width
+        self.data_width = data_width = flash.bus_width
+        self.ddr        = ddr        = flash.ddr
+
+        self.command = command = flash.read_opcode.code
+
+        # Clock Generator.
+        self.submodules.clkgen = clkgen = LiteSPIClkGen(pads, device, with_ddr=ddr)
+        self.comb += [
+            clkgen.div.eq(spi_clk_divisor),
+            clkgen.sample_cnt.eq(1),
+            clkgen.update_cnt.eq(1),
+        ]
+
+        # CS control.
+        cs_timer = WaitTimer(cs_delay + 1) # Ensure cs_delay cycles between XFers.
+        cs_out   = Signal()
+        self.submodules += cs_timer
+        self.comb += cs_timer.wait.eq(self.cs)
+        self.comb += cs_out.eq(cs_timer.done)
+        self.comb += pads.cs_n.eq(~cs_out)
+
+        # I/Os.
+        data_bits = 32
+        cmd_bits  = 8
+
+        dq_o  = Signal(len(pads.dq))
+        dq_i  = Signal(len(pads.dq))
+        dq_oe = Signal(len(pads.dq))
+
+        for i in range(len(pads.dq)):
+            self.specials += SDRTristate(
+                io = pads.dq[i],
+                o  = dq_o[i],
+                oe = dq_oe[i],
+                i  = dq_i[i],
+            )
+
+        # FSM.
+        shift_cnt = Signal(8, reset_less=True)
+        addr      = Signal(addr_bits if not ddr else addr_bits + addr_width, reset_less=True)
+        data      = Signal(data_bits, reset_less=True)
+        cmd       = Signal(cmd_bits,  reset_less=True)
+
+        usr_dout  = Signal(len(sink.data),  reset_less=True)
+        usr_din   = Signal(len(sink.data),  reset_less=True)
+        usr_len   = Signal(len(sink.len),   reset_less=True)
+        usr_width = Signal(len(sink.width), reset_less=True)
+        usr_mask  = Signal(len(sink.mask),  reset_less=True)
+
+        din_width_cases = {1: [NextValue(usr_din, Cat(dq_i[1], usr_din))]}
+        for i in [2, 4, 8]:
+            din_width_cases[i] = [NextValue(usr_din, Cat(dq_i[0:i], usr_din))]
+
+        dout_width_cases = {}
+        for i in [1, 2, 4, 8]:
+            dout_width_cases[i] = [dq_o.eq(usr_dout[-i:])]
+
+        self.submodules.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            sink.ready.eq(cs_out),
+            If(sink.valid & sink.ready,
+                Case(sink.cmd, {
+                    USER: [
+                        NextValue(usr_dout,  sink.data << (32-sink.len)),
+                        NextValue(usr_din,   0),
+                        NextValue(usr_len,   sink.len),
+                        NextValue(usr_width, sink.width),
+                        NextValue(usr_mask,  sink.mask),
+                        NextState("USER")
+                    ]
+                })
+            )
+        )
+
+        def shift_out(width, bits, next_state, trigger=[], op=[], ddr=False):
+            if type(trigger) is not list:
+                trigger = [trigger]
+                op      = [op]
+
+            edge = self.clkgen.negedge if not ddr else trigger[0]
+            res  = [
+                self.clkgen.en.eq(1),
+                If(edge,
+                    NextValue(shift_cnt, shift_cnt+width),
+                    If(shift_cnt == (bits-width),
+                        NextValue(shift_cnt, 0),
+                        NextState(next_state),
+                    ),
+                ),
+            ]
+
+            if len(trigger) == len(op):
+                for i in range(len(trigger)):
+                    res += [If(trigger[i], *op[i])]
+
+            return res
+
+        fsm.act("USER",
+            dq_oe.eq(usr_mask),
+            Case(usr_width, dout_width_cases),
+            shift_out(
+                width      = usr_width,
+                bits       = usr_len,
+                next_state = "USER_END",
+                trigger    = [
+                    clkgen.posedge_reg2, # data sampling
+                    clkgen.negedge,      # data update
+                ],
+                op = [
+                    [Case(usr_width, din_width_cases)],
+                    [NextValue(usr_dout, usr_dout<<usr_width)],
+                ],
+                ddr = False)
+        )
+        fsm.act("USER_END",
+            If(spi_clk_divisor > 0,
+                # Last data cycle was already captured in the USER state.
+                NextState("SEND_USER_DATA"),
+            ).Elif(clkgen.posedge_reg2,
+                # Capture last data cycle.
+                Case(usr_width, din_width_cases),
+                NextState("SEND_USER_DATA"),
+            )
+        )
+        fsm.act("SEND_USER_DATA",
+            source.valid.eq(1),
+            source.last.eq(1),
+            source.data.eq(usr_din),
+            If(source.ready,
+                NextState("IDLE"),
+            )
+        )

--- a/litespi/phy/model.py
+++ b/litespi/phy/model.py
@@ -11,15 +11,123 @@ from litex.soc.interconnect import stream
 
 from litespi.common import *
 
+class LiteSPIPHYModelCore(Module):
+    def __init__(self, flash, init=None, latency=4):
+        self.source     = source = stream.Endpoint(spi_phy2core_layout)
+        self.sink       = sink   = stream.Endpoint(spi_core2phy_layout)
+        self.dummy_bits = Signal(8)
+        self.cs         = Signal()
+
+        mem         = Memory(32, flash.total_size//4, init=init)
+        read_addr   = Signal(32)
+
+        read_port   = mem.get_port(async_read=True)
+
+        self.specials += mem, read_port
+
+        self.comb   += read_port.adr.eq(read_addr)
+
+        cmd_bits    = 8
+
+        delay_cnt   = Signal(8)
+        xfer_len    = Signal(8)
+        xfer_width  = Signal(8)
+
+        def delay_gen(next_state, width=xfer_width, bits=xfer_len, op=[]):
+            res = [
+                If(delay_cnt == (bits - width + latency*width),
+                    source.valid.eq(1),
+                    If(source.ready,
+                        NextValue(delay_cnt, 0),
+                        NextState(next_state),
+                        *op,
+                    ),
+                ).Else(
+                    NextValue(delay_cnt, delay_cnt + width),
+                )
+            ]
+
+            return res
+
+        def wait_gen(next_state, op=[]):
+            res = [
+                sink.ready.eq(1),
+                If(sink.valid,
+                    NextValue(xfer_len, sink.len),
+                    NextValue(xfer_width, sink.width),
+                    NextState(next_state),
+                    *op,
+                )
+            ]
+
+            return res
+
+        self.submodules.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            sink.ready.eq(self.cs),
+            NextValue(read_addr, 0),
+            NextValue(delay_cnt, 0),
+            If(sink.valid & sink.ready,
+                NextValue(xfer_len, sink.len),
+                NextValue(xfer_width, sink.width),
+                If((sink.len == cmd_bits) & (sink.data == flash.read_opcode.code),
+                    NextState("CMD-DELAY"),
+                ).Else(
+                    NextState("OTHER-DELAY"),
+                )
+            )
+        )
+
+        fsm.act("OTHER-DELAY",
+            delay_gen("OTHER-WAIT"),
+            If(~self.cs,
+                NextState("IDLE")
+            )
+        )
+        fsm.act("OTHER-WAIT",
+            wait_gen("OTHER-DELAY"),
+            If(~self.cs,
+                NextState("IDLE")
+            )
+        )
+
+        fsm.act("CMD-DELAY",
+            delay_gen("ADDR-WAIT")
+        )
+        fsm.act("ADDR-WAIT",
+            wait_gen("ADDR-DELAY", op=[NextValue(read_addr, sink.data[2:])]),
+        )
+        fsm.act("ADDR-DELAY",
+            If(self.dummy_bits != 0, 
+                delay_gen("DUMMY-WAIT")
+            ).Else(
+                delay_gen("DATA-WAIT")
+            )
+        )
+        fsm.act("DUMMY-WAIT",
+            wait_gen("DUMMY-DELAY"),
+        )
+        fsm.act("DUMMY-DELAY",
+            delay_gen("DATA-WAIT"),
+        )
+        fsm.act("DATA-WAIT",
+            If(~self.cs,
+                NextState("IDLE")
+            ),
+            wait_gen("DATA-DELAY"),
+        )
+        fsm.act("DATA-DELAY",
+            If(~self.cs,
+                NextState("IDLE")
+            ),
+            source.data.eq(read_port.dat_r),
+            delay_gen("DATA-WAIT", op=[NextValue(read_addr, read_addr+1)]),
+        )
+
 class LiteSPIPHYModel(Module):
     """LiteSPI PHY simulation model.
 
     The ``LiteSPIPHYModel`` class provides a simulation model that can be used instead of the real PHY.
-
-    Parameters
-    ----------
-    size : int
-        Simulated flash memory size.
 
     init : []
         Initialization data for the flash contents.
@@ -35,35 +143,20 @@ class LiteSPIPHYModel(Module):
     cs : Signal()
         Dummy flash CS signal.
     """
-    def __init__(self, size, init=None):
-        self.source = source = stream.Endpoint(spi_phy2core_layout)
-        self.sink   = sink   = stream.Endpoint(spi_core2phy_layout)
-        mem         = Memory(32, size//4, init=init)
-        read_addr   = Signal(32)
-        self.cs     = Signal()
+    def __init__(self, flash, clock_domain="sys", init=None):
+        self.phy        = LiteSPIPHYModelCore(flash, init=init)
+        self.dummy_bits = self.phy.dummy_bits
+        self.source     = self.phy.source
+        self.sink       = self.phy.sink
+        self.cs         = self.phy.cs
+        self.flash      = flash
 
-        read_port   = mem.get_port(async_read=True)
-        self.comb  += read_port.adr.eq(read_addr)
+        # # #
 
-        self.specials += mem, read_port
+        if clock_domain != "sys":
+            self.clock_domains.cd_litespi = ClockDomain()
+            self.phy = ClockDomainsRenamer("litespi")(self.phy)
+            self.comb += self.cd_litespi.clk.eq(ClockSignal(clock_domain))
+            self.comb += self.cd_litespi.rst.eq(ResetSignal(clock_domain))
 
-        commands = {
-            CMD: [NextValue(read_addr, sink.data[2:31])], # word addressed memory
-            READ: [NextState("DATA")],
-        }
-
-        self.submodules.fsm = fsm = FSM(reset_state="IDLE")
-        fsm.act("IDLE",
-            sink.ready.eq(1),
-            If(sink.ready & sink.valid,
-                Case(sink.cmd, commands),
-            ),
-        )
-        fsm.act("DATA",
-            source.valid.eq(1),
-            source.data.eq(read_port.dat_r),
-            If(source.ready & source.valid,
-                NextValue(read_addr, read_addr+1),
-                NextState("IDLE"),
-            ),
-        )
+        self.submodules.spiflash_phy = self.phy

--- a/test/test_spi_mmap.py
+++ b/test/test_spi_mmap.py
@@ -10,14 +10,34 @@ from migen import *
 
 from litespi.core.mmap import LiteSPIMMAP
 from litespi.common import *
+from litespi.opcodes import SpiNorFlashOpCodes as Codes
+from litespi.spi_nor_flash_module import SpiNorFlashModule
+from litespi.ids import SpiNorFlashManufacturerIDs
 
 
 class TestSPIMMAP(unittest.TestCase):
+    class DummyChip(SpiNorFlashModule):
+
+        manufacturer_id = SpiNorFlashManufacturerIDs.NONJEDEC
+        device_id = 0x0204
+        name = "dummychip1"
+
+        total_size  =    2097152   # bytes
+        page_size   =        256   # bytes
+        total_pages =       8192
+
+        supported_opcodes = [
+            Codes.READ_1_1_1,
+            Codes.PP_1_1_1
+        ]
+        dummy_bits = 8
+
     def test_spi_mmap_core_syntax(self):
-        spi_mmap = LiteSPIMMAP()
+        spi_mmap = LiteSPIMMAP(flash=self.DummyChip(Codes.READ_1_1_1, []))
 
     def test_spi_mmap_read_test(self):
-        dut = LiteSPIMMAP()
+        opcode = Codes.READ_1_1_1
+        dut = LiteSPIMMAP(flash=self.DummyChip(opcode, []))
 
         def wb_gen(dut, addr, data):
             dut.data_ok = 0
@@ -29,36 +49,59 @@ class TestSPIMMAP(unittest.TestCase):
 
             while (yield dut.bus.ack) == 0:
                 yield
-
+            print((yield dut.bus.dat_r))
             if (yield dut.bus.dat_r) == data:
                 dut.data_ok = 1
 
         def phy_gen(dut, addr, data):
             dut.addr_ok = 0
+            dut.opcode_ok = 0
             dut.cmd_ok = 0
-
+            dut.no_dummy = 0
             yield dut.sink.valid.eq(0)
             yield dut.source.ready.eq(1)
 
             while (yield dut.source.valid) == 0:
                 yield
 
+
+            # READ CMD
+            if (yield dut.source.cmd) == USER:
+                dut.cmd_ok += 1
+
+            if (yield dut.source.data) == opcode.code: # cmd ok
+                dut.opcode_ok = 1
+
+            yield
+            yield dut.sink.valid.eq(1)
+            while (yield dut.source.valid) == 0:
+                yield
+            yield dut.sink.valid.eq(0)
+
+            # READ ADDR
             if (yield dut.source.data) == (addr<<2): # address cmd
                 dut.addr_ok = 1
-            if (yield dut.source.cmd) == CMD:
+
+            if (yield dut.source.cmd) == USER:
                 dut.cmd_ok += 1
 
             yield
-
+            yield dut.sink.valid.eq(1)
             while (yield dut.source.valid) == 0:
                 yield
+            yield dut.sink.valid.eq(0)
 
-            if (yield dut.source.cmd) == READ: # read cmd
+            # NO DUMMY, mask should be 0 cause we attept to read data
+            if (yield dut.source.mask) == 0:
+                dut.no_dummy = 1
+
+            # SEND DATA
+
+            if (yield dut.source.cmd) == USER: # read cmd
                 dut.cmd_ok += 1
 
             yield dut.source.ready.eq(0)
             yield
-
             yield dut.sink.data.eq(data)
             yield dut.sink.valid.eq(1)
 
@@ -68,11 +111,12 @@ class TestSPIMMAP(unittest.TestCase):
             yield
             yield dut.sink.valid.eq(0)
             yield
-
         addr = 0xcafe
         data = 0xdeadbeef
 
         run_simulation(dut, [wb_gen(dut, addr, data), phy_gen(dut, addr, data)])
         self.assertEqual(dut.data_ok, 1)
         self.assertEqual(dut.addr_ok, 1)
-        self.assertEqual(dut.cmd_ok, 2)
+        self.assertEqual(dut.opcode_ok, 1)
+        self.assertEqual(dut.no_dummy, 1)
+        self.assertEqual(dut.cmd_ok, 3)


### PR DESCRIPTION
With this PR the litespi:
 - has simplified PHY core. CMD and USER states have been reimplemented as USER state in MMAP core.
 - implements the PHY using the ODDR/IDDR cores.
 
 We updated the model.py and tests so they are compatible with new implementation.
Litex PR related to this change can be found under this : https://github.com/enjoy-digital/litex/pull/1024