### PR TITLE
Fix DDR PHY compatibility with Crosslink-NX

### DIFF
--- a/litespi/core/mmap.py
+++ b/litespi/core/mmap.py
@@ -181,7 +181,6 @@ class LiteSPIMMAP(Module, AutoCSR):
         fsm.act("BURST-REQ",
             cs.eq(1),
             source.valid.eq(1),
-            sink.ready.eq(1),
             source.last.eq(1),
             source.width.eq(flash.bus_width),
             source.len.eq(data_bits),

--- a/litespi/core/mmap.py
+++ b/litespi/core/mmap.py
@@ -100,16 +100,7 @@ class LiteSPIMMAP(Module, AutoCSR):
                 # If CS is still active and Bus address matches previous Burst address:
                 # Just continue the current Burst.
                 If(burst_cs & (bus.adr == burst_adr),
-                    source.valid.eq(1),
-                    source.last.eq(1),
-                    source.width.eq(flash.bus_width),
-                    source.len.eq(data_bits),
-                    source.mask.eq(0),
-                    If(source.ready,
-                        NextState("BURST-DAT"),
-                    ).Else(
-                        NextState("BURST-REQ")
-                    )
+                    NextState("BURST-REQ")
                 # Otherwise initialize a new Burst.
                 ).Else(
                     cs.eq(0),
@@ -190,6 +181,7 @@ class LiteSPIMMAP(Module, AutoCSR):
         fsm.act("BURST-REQ",
             cs.eq(1),
             source.valid.eq(1),
+            sink.ready.eq(1),
             source.last.eq(1),
             source.width.eq(flash.bus_width),
             source.len.eq(data_bits),

--- a/litespi/phy/generic.py
+++ b/litespi/phy/generic.py
@@ -45,6 +45,9 @@ class LiteSPIPHY(Module,AutoDoc, AutoCSR,  ModuleDoc):
     rate : str
         Rate: 1:1 SDR, 1:2 DDR.
 
+    extra_latency : int (1:2 rate)
+        Compensate for additional DDROutput/Input latency
+
     Attributes
     ----------
     source : Endpoint(spi_phy2core_layout), out
@@ -57,12 +60,12 @@ class LiteSPIPHY(Module,AutoDoc, AutoCSR,  ModuleDoc):
         Flash CS signal from ``LiteSPIPHYCore``.
     """
 
-    def __init__(self, pads, flash, device="xc7", clock_domain="sys", default_divisor=9, cs_delay=10, rate="1:1"):
+    def __init__(self, pads, flash, device="xc7", clock_domain="sys", default_divisor=9, cs_delay=10, rate="1:1", extra_latency=0):
         assert rate in ["1:1", "1:2"]
         if rate == "1:1":
             self.phy = LiteSPISDRPHYCore(pads, flash, device, clock_domain, default_divisor, cs_delay)
         if rate == "1:2":
-            self.phy = LiteSPIDDRPHYCore(pads, flash, cs_delay)
+            self.phy = LiteSPIDDRPHYCore(pads, flash, cs_delay, extra_latency)
 
         self.flash = flash
 

--- a/litespi/phy/generic_ddr.py
+++ b/litespi/phy/generic_ddr.py
@@ -53,7 +53,7 @@ class LiteSPIDDRPHYCore(Module, AutoCSR, AutoDoc, ModuleDoc):
     cs : Signal(), in
         Flash CS signal.
     """
-    def __init__(self, pads, flash, cs_delay):
+    def __init__(self, pads, flash, cs_delay, extra_latency=0):
         self.source = source = stream.Endpoint(spi_phy2core_layout)
         self.sink   = sink   = stream.Endpoint(spi_core2phy_layout)
         self.cs     = Signal()
@@ -170,7 +170,7 @@ class LiteSPIDDRPHYCore(Module, AutoCSR, AutoDoc, ModuleDoc):
             Case(usr_width, din_width_cases),
             NextValue(dq_i1, 0),
             NextValue(shift_cnt, shift_cnt+usr_width),
-            If(shift_cnt == (2*usr_width),
+            If(shift_cnt == ((2+2*extra_latency)*usr_width),
                 NextValue(shift_cnt, 0),
                 NextState("SEND_USER_DATA"),
             ),


### PR DESCRIPTION
This PR reverts 2 optimizations that were added in #57, It turns out that this version of the MMAP/PHY logic fails on the Crosslink-NX platform (there might be other compatibility issues and I think reverting those commits is the best option for now). This also adds parameter for compensating for  additional latency if needed - setting it to `1` on Crosslink-NX was required to get correct results.