### PR TITLE
SDRPHY: support flash=None

### DIFF
--- a/litespi/phy/generic_sdr.py
+++ b/litespi/phy/generic_sdr.py
@@ -82,16 +82,20 @@ class LiteSPISDRPHYCore(Module, AutoCSR, AutoDoc):
             bus_width = len(pads.dq)
         assert bus_width in [1, 2, 4, 8]
 
-        # Check if number of pads matches configured mode.
-        assert flash.check_bus_width(bus_width)
+        if flash:
+            # Check if number of pads matches configured mode.
+            assert flash.check_bus_width(bus_width)
 
-        self.addr_bits  = addr_bits  = flash.addr_bits
-        self.cmd_width  = cmd_width  = flash.cmd_width
-        self.addr_width = addr_width = flash.addr_width
-        self.data_width = data_width = flash.bus_width
-        self.ddr        = ddr        = flash.ddr
+            self.addr_bits  = addr_bits  = flash.addr_bits
+            self.cmd_width  = cmd_width  = flash.cmd_width
+            self.addr_width = addr_width = flash.addr_width
+            self.data_width = data_width = flash.bus_width
+            self.ddr        = ddr        = flash.ddr
 
-        self.command = command = flash.read_opcode.code
+            self.command = command = flash.read_opcode.code
+        else:
+            # master only
+            self.ddr        = ddr        = False
 
         # Clock Generator.
         self.submodules.clkgen = clkgen = LiteSPIClkGen(pads, device, with_ddr=ddr)


### PR DESCRIPTION
Useful for qspi master-only operation, example integration below:

    from litespi.phy.generic import LiteSPIPHY
    qspi_pads = self.platform.request("qspi1")
    qspi_phy = LiteSPIPHY(qspi_pads, None, device=self.platform.device)
    self.add_module(name="qspi_phy", module=qspi_phy)
    from litespi import LiteSPI
    qspi_core = LiteSPI(qspi_phy, with_mmap=False)
    self.add_module(name="qspi_core", module=qspi_core)