### PR TITLE
mmap: Add write functionality

### DIFF
--- a/litespi/core/mmap.py
+++ b/litespi/core/mmap.py
@@ -2,6 +2,7 @@
 # This file is part of LiteSPI
 #
 # Copyright (c) 2020 Antmicro <www.antmicro.com>
+# Copyright (c) 2024 Matthias Breithaupt <m.breithaupt@vogl-electronic.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *
@@ -40,6 +41,18 @@ class LiteSPIMMAP(Module, AutoCSR):
     endianness : string
         If endianness is set to ``little`` then byte order of each 32-bit word coming from flash will be reversed.
 
+    with_csr : bool
+        The number of dummy bits can be configure when set to True.
+
+    with_write : bool or string "csr"
+        MMAP writes are supported when set to True or "csr". When set to "csr", they are disabled by default but
+        can be enabled on demand using a CSR.
+
+        Please note that only False and "csr" should be used with flash chips! True is only meant for RAM.
+
+        When using "csr" with a flash chip, make sure to erase the corresponding pages of the flash beforehand
+        using the LiteSPI master. It is also recommended to disable mmap writing once it is not required anymore.
+
     Attributes
     ----------
     source : Endpoint(spi_core2phy_layout), out
@@ -55,9 +68,12 @@ class LiteSPIMMAP(Module, AutoCSR):
         CS signal for the flash chip, should be connected to cs signal of the PHY.
 
     dummy_bits : CSRStorage
-        Register which hold a number of dummy bits to send during transmission.
+        Register which holds the number of dummy bits to send during transmission.
+
+    write_config : CSRStorage
+        Optional register holding configuration bits for the write mode.
     """
-    def __init__(self, flash, clock_domain="sys", endianness="big", with_csr=True):
+    def __init__(self, flash, clock_domain="sys", endianness="big", with_csr=True, with_write=False):
         self.source = source = stream.Endpoint(spi_core2phy_layout)
         self.sink   = sink   = stream.Endpoint(spi_phy2core_layout)
         self.bus    = bus    = wishbone.Interface()
@@ -68,6 +84,9 @@ class LiteSPIMMAP(Module, AutoCSR):
         burst_adr     = Signal(len(bus.adr), reset_less=True)
         burst_timeout = WaitTimer(MMAP_DEFAULT_TIMEOUT)
         self.submodules += burst_timeout
+
+        write = Signal()
+        write_enabled = Signal()
 
         cmd_bits  = 8
         data_bits = 32
@@ -92,6 +111,17 @@ class LiteSPIMMAP(Module, AutoCSR):
 
         dummy = Signal(data_bits, reset=0xdead)
 
+        if with_write and with_write == "csr":
+            self.write_config = write_config = CSRStorage(fields=[
+                CSRField("write_enable", size=1, reset=0, description="MMAP write enable"),
+            ])
+            if clock_domain != "sys":
+                self.specials += MultiReg(write_config.fields.write_enable, write_enabled, clock_domain)
+            else:
+                self.comb += write_enabled.eq(write_config.fields.write_enable)
+        else:
+            self.comb += write_enabled.eq(Constant(with_write == True))
+
         # FSM.
         self.submodules.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
@@ -99,16 +129,31 @@ class LiteSPIMMAP(Module, AutoCSR):
             burst_timeout.wait.eq(1),
             NextValue(burst_cs, burst_cs & ~burst_timeout.done),
             cs.eq(burst_cs),
-            # On Bus Read access...
-            If(bus.cyc & bus.stb & ~bus.we,
-                # If CS is still active and Bus address matches previous Burst address:
-                # Just continue the current Burst.
-                If(burst_cs & (bus.adr == burst_adr),
-                    NextState("BURST-REQ")
-                # Otherwise initialize a new Burst.
-                ).Else(
-                    cs.eq(0),
-                    NextState("BURST-CMD")
+            If(bus.cyc & bus.stb,
+                # On Bus Read access...
+                If(~bus.we,
+                    # If CS is still active, Bus address matches previous Burst address and previous access was reading:
+                    # Just continue the current Burst.
+                    If(burst_cs & (bus.adr == burst_adr) & (~write_enabled | ~write),
+                        NextState("BURST-REQ")
+                    # Otherwise initialize a new Burst.
+                    ).Else(
+                        cs.eq(0),
+                        NextState("BURST-CMD")
+                    ),
+                    NextValue(write, 0)
+                # On Bus Write access (if enabled)...
+                ).Elif(write_enabled,
+                    # If CS is still active, Bus address matches previous Burst address and previous access was writing:
+                    # Just continue the current Burst.
+                    If(burst_cs & (bus.adr == burst_adr) & write,
+                        NextState("WRITE")
+                    # Otherwise initialize a new Burst.
+                    ).Else(
+                        cs.eq(0),
+                        NextState("BURST-CMD")
+                    ),
+                    NextValue(write, 1)
                 )
             )
         )
@@ -116,7 +161,11 @@ class LiteSPIMMAP(Module, AutoCSR):
         fsm.act("BURST-CMD",
             cs.eq(1),
             source.valid.eq(1),
-            source.data.eq(flash.read_opcode.code), # send command.
+            If(write_enabled & write,
+                source.data.eq(flash.program_opcode.code), # send command.
+            ).Else(
+                source.data.eq(flash.read_opcode.code), # send command.
+            ),
             source.len.eq(cmd_bits),
             source.width.eq(flash.cmd_width),
             source.mask.eq(cmd_oe_mask[flash.cmd_width]),
@@ -152,7 +201,9 @@ class LiteSPIMMAP(Module, AutoCSR):
             cs.eq(1),
             sink.ready.eq(1),
             If(sink.valid,
-                If(spi_dummy_bits == 0,
+                If(write_enabled & write,
+                    NextState("WRITE"),
+                ).Elif(spi_dummy_bits == 0,
                     NextState("BURST-REQ"),
                 ).Else(
                     NextState("DUMMY"),
@@ -196,6 +247,28 @@ class LiteSPIMMAP(Module, AutoCSR):
             cs.eq(1),
             sink.ready.eq(1),
             bus.dat_r.eq({"big": sink.data, "little": reverse_bytes(sink.data)}[endianness]),
+            If(sink.valid,
+                bus.ack.eq(1),
+                NextValue(burst_adr, burst_adr + 1),
+                NextState("IDLE"),
+            )
+        )
+
+        fsm.act("WRITE",
+            cs.eq(1),
+            source.valid.eq(1),
+            source.width.eq(flash.addr_width),
+            source.mask.eq(addr_oe_mask[flash.bus_width]),
+            source.data.eq({"big": bus.dat_w, "little": reverse_bytes(bus.dat_w)}[endianness]),
+            source.len.eq(data_bits),
+            If(source.ready,
+                NextState("WRITE-RET"),
+            )
+        )
+
+        fsm.act("WRITE-RET",
+            cs.eq(1),
+            sink.ready.eq(1),
             If(sink.valid,
                 bus.ack.eq(1),
                 NextValue(burst_adr, burst_adr + 1),

--- a/litespi/core/mmap.py
+++ b/litespi/core/mmap.py
@@ -216,7 +216,7 @@ class LiteSPIMMAP(Module, AutoCSR):
             cs.eq(1),
             source.valid.eq(1),
             source.width.eq(flash.addr_width),
-            source.mask.eq(addr_oe_mask[flash.addr_width]),
+            source.mask.eq(0),
             source.data.eq(dummy),
             source.len.eq(spi_dummy_bits),
             If(source.ready,

--- a/litespi/core/mmap.py
+++ b/litespi/core/mmap.py
@@ -78,6 +78,7 @@ class LiteSPIMMAP(Module, AutoCSR):
         self.sink   = sink   = stream.Endpoint(spi_phy2core_layout)
         self.bus    = bus    = wishbone.Interface()
         self.cs     = cs     = Signal()
+        self.offset = offset = Signal(len(bus.adr))
 
         # Burst Control.
         burst_cs      = Signal()
@@ -188,7 +189,7 @@ class LiteSPIMMAP(Module, AutoCSR):
             source.valid.eq(1),
             source.width.eq(flash.addr_width),
             source.mask.eq(addr_oe_mask[flash.addr_width]),
-            source.data.eq(Cat(Signal(2), bus.adr)), # send address.
+            source.data.eq(Cat(Signal(2), bus.adr - offset)), # send address.
             source.len.eq(flash.addr_bits),
             NextValue(burst_cs, 1),
             NextValue(burst_adr, bus.adr),


### PR DESCRIPTION
With this change, it is possible to memory map e.g. PSRAM. When setting with_write to "csr", it can also be used to support faster flash writing via etherbone. For flash, only False and "csr" should be used, as the some other logic or application needs to make sure that the flash is erased ahead of time. True is only meant for use with RAM chips.

There are two bugs that this also addresses:
1. ~~Addresses are now masked to flash size or addr_width if no size is set. I'm not 100% happy with this solution, as it might cause issues with non power of 2 flashes (do those exist). However, without this, I would get flash writes to the wishbone address rather than offsets inside the flash. So I'm open to better alternatives. Optimum would be subtracting the base bus address, but I haven't found any clean way of accessing it.~~ I found a way to wire the origin through, so now this can be fixed by wiring through the corresponding addresses (described in the commit message and I will create a PR for LiteX, once this is merged)
2. In quad mode the core was driving all pins for the duration of the dummy bits. Now, the pins are released at the start of the dummy period to not interfere with the pins being driven by the external chip.

Let me know if they should be part of separate ~~commits/~~ PRs.

~~Currently, tests are still to be added.~~

This should fix #25 