### PR TITLE
core: mmap.py: fix dummy bits

### DIFF
--- a/litespi/core/mmap.py
+++ b/litespi/core/mmap.py
@@ -93,12 +93,7 @@ class LiteSPIMMAP(Module, AutoCSR):
         cmd_bits  = 8
         data_bits = 32
 
-        if flash.cmd_width == 1:
-            self._default_dummy_bits = flash.dummy_bits if flash.fast_mode else 0
-        elif flash.cmd_width == 4:
-            self._default_dummy_bits = flash.dummy_bits * 3 if flash.fast_mode else 0
-        else:
-            raise NotImplementedError(f'Command width of {flash.cmd_width} bits is currently not supported!')
+        self._default_dummy_bits = flash.dummy_cycles * flash.addr_width if flash.fast_mode else 0
 
         self._spi_dummy_bits = spi_dummy_bits = Signal(8)
 

--- a/litespi/modules/__init__.py
+++ b/litespi/modules/__init__.py
@@ -1,5 +1,6 @@
 from litespi.modules.generated_modules import *
 from litespi.modules.modules import *
+from litespi.modules.ram_modules import *
 from litespi.spi_nor_flash_module import MetaSizes
 
 def print_modules():

--- a/litespi/modules/modules.py
+++ b/litespi/modules/modules.py
@@ -31,6 +31,12 @@ class MX25L12833F(SpiNorFlashModule):
     ]
     dummy_bits = 8
 
+    dummy_cycles = {
+        SpiNorFlashOpCodes.READ_1_1_1_FAST: 8,
+        SpiNorFlashOpCodes.READ_1_2_2: 8,
+        SpiNorFlashOpCodes.READ_1_4_4: 8,
+        SpiNorFlashOpCodes.READ_4_4_4: 6,
+    }
 
 class MX25L6406E(SpiNorFlashModule):
     """MX25L6406E

--- a/litespi/modules/ram_modules.py
+++ b/litespi/modules/ram_modules.py
@@ -1,0 +1,31 @@
+from litespi.spi_nor_flash_module import SpiNorFlashModule
+from litespi.opcodes import SpiNorFlashOpCodes as Codes
+from litespi.ids import SpiNorFlashManufacturerIDs
+
+# Define non-generated SPI PSRAM chips here
+
+class APS6404L(SpiNorFlashModule):
+    manufacturer_id = SpiNorFlashManufacturerIDs.NONJEDEC # AP Memory
+    device_id = 0x0000
+    name = "aps6404l"
+
+    total_size  =   8388608  # bytes
+    page_size   =       128  # bytes
+    total_pages =     65536
+
+    supported_opcodes = [
+        Codes.READ_1_1_1,       # max 33 MHz
+        Codes.READ_1_1_1_FAST,  # max 84 MHz
+        Codes.READ_1_4_4,       # max 84 MHz
+        Codes.READ_4_4_4_LOW,   # max 66 MHz
+        Codes.READ_4_4_4,       # max 84 MHz
+        Codes.PP_1_1_1,         # max 84 MHz
+        Codes.PP_1_4_4,         # max 84 MHz
+    ]
+
+    dummy_cycles = {
+        Codes.READ_1_1_1_FAST: 8,
+        Codes.READ_1_4_4: 6,
+        Codes.READ_4_4_4_LOW: 4,
+        Codes.READ_4_4_4: 6,
+    }

--- a/litespi/opcodes.py
+++ b/litespi/opcodes.py
@@ -33,6 +33,7 @@ class SpiNorFlashOpCodes:
     READ_1_2_2         = _Op(0xbb, "Read data bytes (Dual I/O SPI)")
     READ_1_1_4         = _Op(0x6b, "Read data bytes (Quad Output SPI)")
     READ_1_4_4         = _Op(0xeb, "Read data bytes (Quad I/O SPI)") # Fast Read Quad
+    READ_4_4_4_LOW     = _Op(0x0b, "Read data bytes (Quad I/O QPI) (low frequency)") # might need less dummy cycles
     READ_4_4_4         = _Op(0xeb, "Read data bytes (Quad I/O QPI)")
     READ_1_1_8         = _Op(0x8b, "Read data bytes (Octal Output SPI)")
     READ_1_8_8         = _Op(0xcb, "Read data bytes (Octal I/O SPI)")

--- a/litespi/spi_nor_flash_module.py
+++ b/litespi/spi_nor_flash_module.py
@@ -165,13 +165,19 @@ Read command (%s) not supported in chip %s!""" % (str(cmd), self.name))
         assert hasattr(self, 'page_size')
         assert hasattr(self, 'total_pages')
         assert hasattr(self, 'supported_opcodes')
-        assert hasattr(self, 'dummy_bits')
+        assert hasattr(self, 'dummy_bits') or hasattr(self, 'dummy_cycles')
 
         # Make sure default read command is on the list
         if default_read_cmd not in read_cmds:
             read_cmds.append(default_read_cmd)
 
         self.read_cmds = read_cmds
+
+        if hasattr(self, "dummy_cycles"):
+            if isinstance(self.dummy_cycles, dict):
+                self.dummy_cycles = self.dummy_cycles.get(default_read_cmd, self.dummy_bits if hasattr(self, 'dummy_bits') else 0)
+        else:
+            self.dummy_cycles = self.dummy_bits
 
         # Configure a chip using provided default_read_cmd
         self._configure_chip(default_read_cmd,


### PR DESCRIPTION
ths commit fixes the dummy bits calculation in the litespi core.
The dummy bits are now calculated correctly based on dummy cyles
and these are now correctly set in the spi_nor_flash_module.

THis also lets you add a dict to the flash module named dummy_cycles, where the amount of cycles can be set for each op code.