### PR TITLE
spi_nor_flash_module.py: fix read_cmds array

### DIFF
--- a/litespi/modules/generated_modules.py
+++ b/litespi/modules/generated_modules.py
@@ -8121,8 +8121,15 @@ class W25Q128JV(SpiNorFlashModule):
         SpiNorFlashOpCodes.PP_1_1_2,
         SpiNorFlashOpCodes.READ_1_1_4,
         SpiNorFlashOpCodes.PP_1_1_4,
+        SpiNorFlashOpCodes.READ_1_2_2,
+        SpiNorFlashOpCodes.READ_1_4_4,
     ]
     dummy_bits = 8
+
+    dummy_cycles = {
+        SpiNorFlashOpCodes.READ_1_2_2: 0,
+        SpiNorFlashOpCodes.READ_1_4_4: 4,
+    }
 
 
 class W25Q16DW(SpiNorFlashModule):

--- a/litespi/spi_nor_flash_module.py
+++ b/litespi/spi_nor_flash_module.py
@@ -154,7 +154,7 @@ Read command (%s) not supported in chip %s!""" % (str(cmd), self.name))
         self.erase_opcode = erase_cmd
 
     def __init__(self, default_read_cmd,
-                 read_cmds=[],
+                 read_cmds=None,
                  program_cmd=SpiNorFlashOpCodes.PP_1_1_1,
                  erase_cmd=SpiNorFlashOpCodes.SE):
         # Check if mandatory attributes are set by an inheritor
@@ -167,6 +167,8 @@ Read command (%s) not supported in chip %s!""" % (str(cmd), self.name))
         assert hasattr(self, 'supported_opcodes')
         assert hasattr(self, 'dummy_bits') or hasattr(self, 'dummy_cycles')
 
+        if read_cmds is None:
+            read_cmds = []
         # Make sure default read command is on the list
         if default_read_cmd not in read_cmds:
             read_cmds.append(default_read_cmd)

--- a/litespi/spi_nor_flash_module.py
+++ b/litespi/spi_nor_flash_module.py
@@ -146,7 +146,7 @@ Read command (%s) not supported in chip %s!""" % (str(cmd), self.name))
 
         # Check if program command is supported
         if program_cmd not in self.supported_opcodes:
-            raise ValueError("Read command (%s) not supported in chip %s!" % (str(read_cmd), self.name))
+            raise ValueError("Programm command (%s) not supported in chip %s!" % (str(program_cmd), self.name))
 
         # Set commands
         self.read_opcode = default_read_cmd


### PR DESCRIPTION
@enjoy-digital 
If more that one module is used with incompatible read_cmds, it leads to a a raised ValueError (Read command ... not supported in chip ...).
This fixes it so the different modules wont share a common read_cmds array if that is not explicitly defined.

also adds modes for the W25Q128JV.