### PR TITLE
phy: cleanup

### DIFF
--- a/litespi/clkgen.py
+++ b/litespi/clkgen.py
@@ -51,9 +51,6 @@ class LiteSPIClkGen(Module, AutoDoc):
     cnt_width : int
         Width of the internal counter ``cnt`` used for dividing the clock.
 
-    with_ddr : bool
-        Generate additional ``sample`` and ``update`` signals.
-
     Attributes
     ----------
     div : Signal(8), in
@@ -67,27 +64,11 @@ class LiteSPIClkGen(Module, AutoDoc):
 
     en : Signal(), in
         Clock enable input, output clock will be generated if set to 1, 0 resets the core.
-
-    sample : Signal(), out
-        Outputs 1 when ``sample_cnt==cnt``, can be used to sample incoming DDR data.
-
-    sample_cnt : Signal(8), in
-        Controls generation of the ``sample`` signal.
-
-    update : Signal(), out
-        Outputs 1 when ``update_cnt==cnt``, can be used to update outgoing DDR data.
-
-    update_cnt : Signal(8), in
-        Controls generation of the ``update`` signal.
     """
-    def __init__(self, pads, device, cnt_width=8, with_ddr=False):
+    def __init__(self, pads, device, cnt_width=8):
         self.div        = div        = Signal(cnt_width)
-        self.sample_cnt = sample_cnt = Signal(cnt_width)
-        self.update_cnt = update_cnt = Signal(cnt_width)
         self.posedge    = posedge    = Signal()
         self.negedge    = negedge    = Signal()
-        self.sample     = sample     = Signal()
-        self.update     = update     = Signal()
         self.en         = en         = Signal()
         cnt             = Signal(cnt_width)
         en_int          = Signal()
@@ -96,8 +77,6 @@ class LiteSPIClkGen(Module, AutoDoc):
         self.comb += [
             posedge.eq(en & ~clk & (cnt == div)),
             negedge.eq(en & clk & (cnt == div)),
-            sample.eq(cnt == sample_cnt),
-            update.eq(cnt == update_cnt),
         ]
 
         # Delayed edge to account for IO register delays.

--- a/litespi/phy/generic_ddr.py
+++ b/litespi/phy/generic_ddr.py
@@ -67,13 +67,10 @@ class LiteSPIDDRPHYCore(Module, AutoCSR, AutoDoc):
 
         assert bus_width in [1, 2, 4, 8]
 
-        # Check if number of pads matches configured mode.
-        assert flash.check_bus_width(bus_width)
-
-        self.addr_bits  = addr_bits  = flash.addr_bits
-        self.ddr        = ddr        = flash.ddr
-
-        assert not ddr
+        if flash:
+            # Check if number of pads matches configured mode.
+            assert flash.check_bus_width(bus_width)
+            assert not flash.ddr
 
         # Clock Generator.
         self.submodules.clkgen = clkgen = DDRLiteSPIClkGen(pads)

--- a/litespi/phy/generic_sdr.py
+++ b/litespi/phy/generic_sdr.py
@@ -85,25 +85,11 @@ class LiteSPISDRPHYCore(Module, AutoCSR, AutoDoc):
         if flash:
             # Check if number of pads matches configured mode.
             assert flash.check_bus_width(bus_width)
-
-            self.addr_bits  = addr_bits  = flash.addr_bits
-            self.cmd_width  = cmd_width  = flash.cmd_width
-            self.addr_width = addr_width = flash.addr_width
-            self.data_width = data_width = flash.bus_width
-            self.ddr        = ddr        = flash.ddr
-
-            self.command = command = flash.read_opcode.code
-        else:
-            # master only
-            self.ddr        = ddr        = False
+            assert not flash.ddr
 
         # Clock Generator.
-        self.submodules.clkgen = clkgen = LiteSPIClkGen(pads, device, with_ddr=ddr)
-        self.comb += [
-            clkgen.div.eq(spi_clk_divisor),
-            clkgen.sample_cnt.eq(1),
-            clkgen.update_cnt.eq(1),
-        ]
+        self.submodules.clkgen = clkgen = LiteSPIClkGen(pads, device)
+        self.comb += clkgen.div.eq(spi_clk_divisor)
 
         # CS control.
         cs_timer  = WaitTimer(cs_delay + 1) # Ensure cs_delay cycles between XFers.


### PR DESCRIPTION
@enjoy-digital 
this removes some unused variables and stuff that was used with dtr flash modes, which are already no longer supported.