### PR TITLE
mmap: remove offset logic

### DIFF
--- a/litespi/core/mmap.py
+++ b/litespi/core/mmap.py
@@ -80,7 +80,6 @@ class LiteSPIMMAP(LiteXModule):
         self.sink   = sink   = stream.Endpoint(spi_phy2core_layout)
         self.bus    = bus    = wishbone.Interface()
         self.cs     = cs     = Signal()
-        self.offset = offset = Signal(len(bus.adr))
 
         # Burst Control.
         burst_cs      = Signal()
@@ -208,7 +207,7 @@ class LiteSPIMMAP(LiteXModule):
             source.valid.eq(1),
             source.width.eq(flash.addr_width),
             source.mask.eq(addr_oe_mask[flash.addr_width]),
-            source.data.eq(Cat(byte_count, bus.adr - offset)), # send address.
+            source.data.eq(Cat(byte_count, bus.adr)), # send address.
             source.len.eq(flash.addr_bits),
             NextValue(burst_cs, 1),
             NextValue(burst_adr, bus.adr),

--- a/test/test_spi_mmap.py
+++ b/test/test_spi_mmap.py
@@ -40,11 +40,10 @@ class TestSPIMMAP(unittest.TestCase):
         opcode = Codes.PP_1_1_1
         dut = LiteSPIMMAP(flash=self.DummyChip(Codes.READ_1_1_1, [], program_cmd=opcode), with_write=True)
 
-        def wb_gen(dut, addr, data, offset):
+        def wb_gen(dut, addr, data):
             dut.done = 0
 
-            yield dut.offset.eq(offset)
-            yield from dut.bus.write(addr + offset, data)
+            yield from dut.bus.write(addr, data)
 
             dut.done = 1
 
@@ -90,9 +89,8 @@ class TestSPIMMAP(unittest.TestCase):
             yield
         addr = 0xcafe
         data = 0xdeadbeef
-        offset = 0x10000
 
-        run_simulation(dut, [wb_gen(dut, addr, data, offset), phy_gen(dut, addr, data)])
+        run_simulation(dut, [wb_gen(dut, addr, data), phy_gen(dut, addr, data)])
         self.assertEqual(dut.done, 1)
         self.assertEqual(dut.addr_ok, 1)
         self.assertEqual(dut.opcode_ok, 1)


### PR DESCRIPTION
remove offset logic, this is now handled centrally here:
https://github.com/enjoy-digital/litex/pull/2166

By the way, the former implementation for the offset was done wrong.
That offset was applied to the wishbone `adr` only, but it should have been shifted by 2,
as it is word aligned.

``source.data.eq(Cat(byte_count, bus.adr - offset)),`` should have been ``source.data.eq(Cat(byte_count, bus.adr) - offset),`` 
