### PR TITLE
phy: sdr: only change Clk Divisor, when inactive

### DIFF
--- a/litespi/phy/generic_sdr.py
+++ b/litespi/phy/generic_sdr.py
@@ -88,10 +88,12 @@ class LiteSPISDRPHYCore(LiteXModule):
 
         # Clock Generator.
         self.clkgen = clkgen = LiteSPIClkGen(pads, device)
-        self.comb += clkgen.div.eq(spi_clk_divisor)
 
         # CS control.
         self.cs_control = cs_control = LiteSPICSControl(pads, self.cs, cs_delay)
+
+         # Only Clk Divisor when not active.
+        self.sync += If(~cs_control.enable, clkgen.div.eq(spi_clk_divisor))
 
         if hasattr(pads, "mosi"):
             dq_o  = Signal()


### PR DESCRIPTION
only change clk divisor, when cs is inactive,
so it won't be changed during a xfer.

similar logic is already used in LiteI2C https://github.com/litex-hub/litei2c/blob/main/litei2c/phy/generic.py

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>