### PR TITLE
phy: add ddr variant with clk divider

### DIFF
--- a/litespi/clkgen.py
+++ b/litespi/clkgen.py
@@ -176,6 +176,7 @@ class LiteSPIClkGen2(LiteXModule):
         self.posedge    = posedge    = Signal(2)
         self.negedge    = negedge    = Signal(2)
         self.en         = en         = Signal()
+        self.start      = start      = Signal()
         cnt             = Signal(div_width + 1)
         clk             = Signal(2)
         next_clk        = Signal(2)
@@ -185,26 +186,41 @@ class LiteSPIClkGen2(LiteXModule):
         self.comb += double_div.eq(Cat(C(0,1), div))
 
         self.comb += [
-                If(cnt == 2,
-                   next_cnt.eq(double_div),
-                   next_clk[0].eq(cnt <= div),
-                   next_clk[1].eq(1),
-               ).Elif(cnt <= 1,
-                   next_cnt.eq(double_div - 1),
-                   next_clk[0].eq(1),
-                   next_clk[1].eq(0),
-               ).Else(
-                    next_cnt.eq(cnt - 2),
-                    next_clk[0].eq(cnt <= div),
-                    next_clk[1].eq((cnt - 1) <= div),
+            If(start,
+                en.eq(1),
+                If(double_div == 2,
+                    next_cnt.eq(2),
+                    next_clk[0].eq(0),
+                    next_clk[1].eq(1),
+                ).Elif(double_div <= 1,
+                    next_cnt.eq(1),
+                    next_clk[0].eq(1),
+                    next_clk[1].eq(0),
+                ).Else(
+                    next_cnt.eq(double_div - 2),
+                    next_clk[0].eq(0),
+                    next_clk[1].eq(0),
                 ),
+            ).Elif(cnt == 2,
+               next_cnt.eq(double_div),
+               next_clk[0].eq(cnt <= div),
+               next_clk[1].eq(1),
+            ).Elif(cnt <= 1,
+                next_cnt.eq(double_div - 1),
+                next_clk[0].eq(1),
+                next_clk[1].eq(0),
+            ).Else(
+                next_cnt.eq(cnt - 2),
+                next_clk[0].eq(cnt <= div),
+                next_clk[1].eq((cnt - 1) <= div),
+            ),
         ]
 
         self.comb += [
-            posedge[0].eq(en & ~clk[1] & next_clk[0]),
-            negedge[0].eq(en &  clk[1] & ~next_clk[0]),
-            posedge[1].eq(en & ~next_clk[0] & next_clk[1]),
-            negedge[1].eq(en &  next_clk[0] & ~next_clk[1]),
+            posedge[0].eq(en &      ~clk[1] &  next_clk[0]),
+            negedge[0].eq(           clk[1] & ~next_clk[0]),
+            posedge[1].eq(en & ~next_clk[0] &  next_clk[1]),
+            negedge[1].eq(      next_clk[0] & ~next_clk[1]),
         ]
 
         # Delayed edge to account for IO register delays.
@@ -223,7 +239,7 @@ class LiteSPIClkGen2(LiteXModule):
                 clk.eq(next_clk),
             ).Else(
                 clk.eq(0),
-                cnt.eq(double_div),
+                cnt.eq(0),
             )
         ]
 

--- a/litespi/clkgen.py
+++ b/litespi/clkgen.py
@@ -229,6 +229,9 @@ class LiteSPIClkGen2(LiteXModule):
 
         self.sync += [
             posedge_reg.eq(Cat(posedge_reg[2:], posedge)),
+            If(start,
+                posedge_reg.eq(Cat(C(0, len(posedge_reg) - 2), posedge)),
+            ),
         ]
 
         self.comb += posedge_reg2.eq(posedge_reg[:2])

--- a/litespi/clkgen.py
+++ b/litespi/clkgen.py
@@ -2,6 +2,7 @@
 # This file is part of LiteSPI
 #
 # Copyright (c) 2020 Antmicro <www.antmicro.com>
+# Copyright (c) 2025 Fin Maaß <f.maass@vogl-electronic.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *
@@ -142,3 +143,88 @@ class LiteSPIClkGen(LiteXModule):
                 raise NotImplementedError
         else:
             self.specials += SDROutput(i=clk, o=pads.clk)
+
+class LiteSPIClkGen2(LiteXModule):
+    """SPI Clock generator
+
+    The ``LiteSPIClkGen`` class provides a generic SPI DDR clock generator.
+
+    Parameters
+    ----------
+    pads : Object
+        SPI pads description.
+
+    div_width : int
+        Width of the ``div`` used for dividing the clock.
+
+    Attributes
+    ----------
+    div : Signal(8), in
+        Clock divisor, output clock frequency will be equal to ``sys_clk_freq/div``.
+
+    posedge : Signal(), out
+        Outputs 1 when there is a rising edge on the generated clock, 0 otherwise.
+
+    negedge : Signal(), out
+        Outputs 1 when there is a falling edge on the generated clock, 0 otherwise.
+
+    en : Signal(), in
+        Clock enable input, output clock will be generated if set to 1, 0 resets the core.
+    """
+    def __init__(self, pads, div_width=8, extra_latency=0):
+        self.div        = div        = Signal(div_width)
+        self.posedge    = posedge    = Signal(2)
+        self.negedge    = negedge    = Signal(2)
+        self.en         = en         = Signal()
+        cnt             = Signal(div_width + 1)
+        clk             = Signal(2)
+        next_clk        = Signal(2)
+        next_cnt        = Signal(div_width + 1)
+
+        double_div = Signal(div_width + 1)
+        self.comb += double_div.eq(Cat(C(0,1), div))
+
+        self.comb += [
+                If(cnt == 2,
+                   next_cnt.eq(double_div),
+                   next_clk[0].eq(cnt <= div),
+                   next_clk[1].eq(1),
+               ).Elif(cnt <= 1,
+                   next_cnt.eq(double_div - 1),
+                   next_clk[0].eq(1),
+                   next_clk[1].eq(0),
+               ).Else(
+                    next_cnt.eq(cnt - 2),
+                    next_clk[0].eq(cnt <= div),
+                    next_clk[1].eq((cnt - 1) <= div),
+                ),
+        ]
+
+        self.comb += [
+            posedge[0].eq(en & ~clk[1] & next_clk[0]),
+            negedge[0].eq(en &  clk[1] & ~next_clk[0]),
+            posedge[1].eq(en & ~next_clk[0] & next_clk[1]),
+            negedge[1].eq(en &  next_clk[0] & ~next_clk[1]),
+        ]
+
+        # Delayed edge to account for IO register delays.
+        posedge_reg  = Signal(2 + 2 + 2 + int(extra_latency))
+        self.posedge_reg2 = posedge_reg2 = Signal(2)
+
+        self.sync += [
+            posedge_reg.eq(Cat(posedge_reg[2:], posedge)),
+        ]
+
+        self.comb += posedge_reg2.eq(posedge_reg[:2])
+
+        self.sync += [
+            If(en,
+                cnt.eq(next_cnt),
+                clk.eq(next_clk),
+            ).Else(
+                clk.eq(0),
+                cnt.eq(double_div),
+            )
+        ]
+
+        self.specials += DDROutput(i1=(en & clk[0]), i2=(en & clk[1]), o=pads.clk)

--- a/litespi/phy/generic.py
+++ b/litespi/phy/generic.py
@@ -12,6 +12,7 @@ from litespi.common import *
 
 from litespi.phy.generic_sdr import LiteSPISDRPHYCore
 from litespi.phy.generic_ddr import LiteSPIDDRPHYCore
+from litespi.phy.generic_ddr_with_clk import LiteSPIDDRPHYCore2
 
 # LiteSPI PHY --------------------------------------------------------------------------------------
 
@@ -61,7 +62,7 @@ class LiteSPIPHY(LiteXModule):
         if rate == "1:1":
             phy = LiteSPISDRPHYCore(pads, flash, device, clock_domain, **kwargs)
         if rate == "1:2":
-            phy = LiteSPIDDRPHYCore(pads, flash, **kwargs)
+            phy = LiteSPIDDRPHYCore2(pads, flash, clock_domain, **kwargs)
 
         self.flash = flash
 

--- a/litespi/phy/generic_ddr.py
+++ b/litespi/phy/generic_ddr.py
@@ -78,13 +78,13 @@ class LiteSPIDDRPHYCore(LiteXModule):
 
         dq_o  = Array([Signal(len(pads.dq)) for _ in range(2)])
         dq_i  = Array([Signal(len(pads.dq)) for _ in range(2)])
-        dq_oe = Array([Signal(len(pads.dq)) for _ in range(2)])
+        dq_oe = Signal(len(pads.dq))
 
         self.specials += DDRTristate(
             io  = pads.dq,
             o1  =  dq_o[0],  o2 =  dq_o[1],
-            oe1 = dq_oe[0], oe2 = dq_oe[1],
-            i1  =  dq_i[0],  i2 =  dq_i[1]
+            i1  =  dq_i[0],  i2 =  dq_i[1],
+            oe1 =  dq_oe,
         )
 
         # Data Shift Registers.
@@ -97,7 +97,7 @@ class LiteSPIDDRPHYCore(LiteXModule):
 
         # Data Out Shift.
         self.comb += [
-            dq_oe[1].eq(sink.mask),
+            dq_oe.eq(sink.mask),
             Case(sink.width, {
                 1:  dq_o[1].eq(sr_out[-1:]),
                 2:  dq_o[1].eq(sr_out[-2:]),
@@ -109,7 +109,6 @@ class LiteSPIDDRPHYCore(LiteXModule):
             sr_out.eq(sink.data << (len(sink.data) - sink.len))
         )
         self.sync += If(sr_out_shift,
-            dq_oe[0].eq(dq_oe[1]),
             dq_o[0].eq(dq_o[1]),
             Case(sink.width, {
                 1 : sr_out.eq(Cat(Signal(1), sr_out)),

--- a/litespi/phy/generic_ddr_with_clk.py
+++ b/litespi/phy/generic_ddr_with_clk.py
@@ -98,7 +98,6 @@ class LiteSPIDDRPHYCore2(LiteXModule):
         dq_o  = Array([Signal(dq_len, name="dq_o"+str(n)) for n in range(2)])
         dq_i  = Array([Signal(dq_len, name="dq_i"+str(n)) for n in range(2)])
         dq_oe = Signal(dq_len)
-        last_dq_oe = Signal(dq_len)
 
         self.specials += DDRTristate(
             io  = pads.dq,
@@ -117,6 +116,7 @@ class LiteSPIDDRPHYCore2(LiteXModule):
         sr_out_loaded  = Signal(len(sink.data), reset_less=True)
         sr_in_shift  = Signal(2)
         sr_in        = Signal(len(sink.data), reset_less=True)
+        sr_in_now    = Signal(len(sink.data), reset_less=True)
 
         no_read = Signal()
         last_sink_width = Signal.like(sink.width)
@@ -134,7 +134,6 @@ class LiteSPIDDRPHYCore2(LiteXModule):
 
         # Data Out Shift.
         self.comb += [
-            dq_oe.eq(last_dq_oe),
             Case(last_sink_width, {
                 1:  dq_o[1].eq(sr_out[-1:]),
                 2:  dq_o[1].eq(sr_out[-2:]),
@@ -173,23 +172,32 @@ class LiteSPIDDRPHYCore2(LiteXModule):
         )
 
         # Data In Shift.
-        self.sync += If(sr_in_shift[0],
+        self.comb += If(sr_in_shift[0],
             Case(last_sink_width, {
-                1 : sr_in.eq(Cat(dq_i[0][1],  sr_in)), # 1: pads.miso
-                2 : sr_in.eq(Cat(dq_i[0][:2], sr_in)),
-                4 : sr_in.eq(Cat(dq_i[0][:4], sr_in)),
-                8 : sr_in.eq(Cat(dq_i[0][:8], sr_in)),
+                1 : sr_in_now.eq(Cat(dq_i[0][1],  sr_in)), # 1: pads.miso
+                2 : sr_in_now.eq(Cat(dq_i[0][:2], sr_in)),
+                4 : sr_in_now.eq(Cat(dq_i[0][:4], sr_in)),
+                8 : sr_in_now.eq(Cat(dq_i[0][:8], sr_in)),
             }),
-            sr_in_cnt.eq(sr_in_cnt - last_sink_width),
         ).Elif(sr_in_shift[1],
             Case(last_sink_width, {
-                1 : sr_in.eq(Cat(dq_i[1][1],  sr_in)), # 1: pads.miso
-                2 : sr_in.eq(Cat(dq_i[1][:2], sr_in)),
-                4 : sr_in.eq(Cat(dq_i[1][:4], sr_in)),
-                8 : sr_in.eq(Cat(dq_i[1][:8], sr_in)),
+                1 : sr_in_now.eq(Cat(dq_i[1][1],  sr_in)), # 1: pads.miso
+                2 : sr_in_now.eq(Cat(dq_i[1][:2], sr_in)),
+                4 : sr_in_now.eq(Cat(dq_i[1][:4], sr_in)),
+                8 : sr_in_now.eq(Cat(dq_i[1][:8], sr_in)),
             }),
-            sr_in_cnt.eq(sr_in_cnt - last_sink_width),
+        ).Else(
+            sr_in_now.eq(sr_in),
         )
+
+        self.sync += [
+            If(sr_in_shift,
+                sr_in_cnt.eq(sr_in_cnt - last_sink_width),
+            ),
+            sr_in.eq(sr_in_now),
+        ]
+
+        self.comb += source.data.eq(sr_in_now),
 
         # FSM.
         self.fsm = fsm = FSM(reset_state="WAIT-CMD-DATA")
@@ -199,8 +207,7 @@ class LiteSPIDDRPHYCore2(LiteXModule):
             If(cs_control.enable & sink.valid,
                 self.clkgen.start.eq(1),
                 NextValue(last_sink_width, sink.width),
-                NextValue(last_dq_oe, sink.mask),
-                dq_oe.eq(sink.mask),
+                NextValue(dq_oe, sink.mask),
                 sr_out_load.eq(1),
                 sink.ready.eq(1),
                 If(sink.clk_div > 0,
@@ -223,10 +230,14 @@ class LiteSPIDDRPHYCore2(LiteXModule):
 
             # Shift Register Count Update/Check.
             If((self.clkgen.negedge != 0) & (sr_out_cnt == 0),
-                self.clkgen.en.eq(0),
                 NextState("XFER-END"),
+                NextValue(dq_oe, 0),
                 If(no_read | (sr_in_cnt == 0) | ((clkgen.posedge_reg2 != 0) & (sr_in_cnt == last_sink_width)),
                     NextState("SEND-STATUS-DATA"),
+                    source.valid.eq(1),
+                    If(source.ready,
+                        NextState("WAIT-CMD-DATA"),
+                    ),
                 ),
             ),
 
@@ -236,9 +247,12 @@ class LiteSPIDDRPHYCore2(LiteXModule):
             If((clkgen.posedge_reg2 != 0) & (sr_in_cnt == last_sink_width),
                 # Send Status/Data to Core.
                 NextState("SEND-STATUS-DATA"),
+                source.valid.eq(1),
+                If(source.ready,
+                    NextState("WAIT-CMD-DATA"),
+                ),
             ),
         )
-        self.comb += source.data.eq(sr_in)
         fsm.act("SEND-STATUS-DATA",
             # Send Data In to Core and return to WAIT when accepted.
             source.valid.eq(1),

--- a/litespi/phy/generic_ddr_with_clk.py
+++ b/litespi/phy/generic_ddr_with_clk.py
@@ -93,20 +93,12 @@ class LiteSPIDDRPHYCore2(LiteXModule):
 
         spi_clk_divisor_delayed = Signal(len(sink.clk_div))
 
-        # Only Clk Divisor when not active or when set by core.
-        self.sync += If(~clkgen.en, spi_clk_divisor_delayed.eq(spi_clk_divisor))
-
-        self.comb += [
-            If(sink.valid & (sink.clk_div > 0),
-                clkgen.div.eq(sink.clk_div),
-            ).Else(
-                clkgen.div.eq(spi_clk_divisor_delayed),
-            )
-        ]
+        self.comb += clkgen.div.eq(spi_clk_divisor_delayed)
 
         dq_o  = Array([Signal(dq_len, name="dq_o"+str(n)) for n in range(2)])
         dq_i  = Array([Signal(dq_len, name="dq_i"+str(n)) for n in range(2)])
         dq_oe = Signal(dq_len)
+        last_dq_oe = Signal(dq_len)
 
         self.specials += DDRTristate(
             io  = pads.dq,
@@ -126,16 +118,30 @@ class LiteSPIDDRPHYCore2(LiteXModule):
         sr_in_shift  = Signal(2)
         sr_in        = Signal(len(sink.data), reset_less=True)
 
+        no_read = Signal()
+        last_sink_width = Signal.like(sink.width)
+
+        # Determine if no read is expected based on mask for current transfer width,
+        # so we can skip waiting for data in the case of write-only transfers.
+        self.sync += If(sr_out_load,
+            Case(sink.width, {
+                "default" : no_read.eq(0),
+                2 : no_read.eq(sink.mask == 0b00000011),
+                4 : no_read.eq(sink.mask == 0b00001111),
+                8 : no_read.eq(sink.mask == 0b11111111),
+            })
+        )
+
         # Data Out Shift.
         self.comb += [
-            dq_oe.eq(sink.mask),
-            Case(sink.width, {
+            dq_oe.eq(last_dq_oe),
+            Case(last_sink_width, {
                 1:  dq_o[1].eq(sr_out[-1:]),
                 2:  dq_o[1].eq(sr_out[-2:]),
                 4:  dq_o[1].eq(sr_out[-4:]),
                 8:  dq_o[1].eq(sr_out[-8:]),
             }),
-            sr_out_shifted.eq(sr_out << sink.width),
+            sr_out_shifted.eq(sr_out << last_sink_width),
             sr_out_loaded.eq(sink.data << (len(sink.data) - sink.len))
         ]
         self.sync += If(sr_out_load,
@@ -147,49 +153,60 @@ class LiteSPIDDRPHYCore2(LiteXModule):
                 4:  dq_o[0].eq(sr_out_loaded[-4:]),
                 8:  dq_o[0].eq(sr_out_loaded[-8:]),
             }),
+            sr_out_cnt.eq(sink.len - sink.width),
+            sr_in_cnt.eq(sink.len),
         ).Elif(sr_out_shift[0],
-            Case(sink.width, {
+            Case(last_sink_width, {
                 1:  dq_o[0].eq(sr_out_shifted[-1:]),
                 2:  dq_o[0].eq(sr_out_shifted[-2:]),
                 4:  dq_o[0].eq(sr_out_shifted[-4:]),
                 8:  dq_o[0].eq(sr_out_shifted[-8:]),
             }),
             sr_out.eq(sr_out_shifted),
+            sr_out_cnt.eq(sr_out_cnt - last_sink_width),
         ).Elif(sr_out_shift[1],
             dq_o[0].eq(dq_o[1]),
             sr_out.eq(sr_out_shifted),
+            sr_out_cnt.eq(sr_out_cnt - last_sink_width),
         ).Else(
             dq_o[0].eq(dq_o[1]),
         )
 
         # Data In Shift.
         self.sync += If(sr_in_shift[0],
-            Case(sink.width, {
+            Case(last_sink_width, {
                 1 : sr_in.eq(Cat(dq_i[0][1],  sr_in)), # 1: pads.miso
                 2 : sr_in.eq(Cat(dq_i[0][:2], sr_in)),
                 4 : sr_in.eq(Cat(dq_i[0][:4], sr_in)),
                 8 : sr_in.eq(Cat(dq_i[0][:8], sr_in)),
-            })
+            }),
+            sr_in_cnt.eq(sr_in_cnt - last_sink_width),
         ).Elif(sr_in_shift[1],
-            Case(sink.width, {
+            Case(last_sink_width, {
                 1 : sr_in.eq(Cat(dq_i[1][1],  sr_in)), # 1: pads.miso
                 2 : sr_in.eq(Cat(dq_i[1][:2], sr_in)),
                 4 : sr_in.eq(Cat(dq_i[1][:4], sr_in)),
                 8 : sr_in.eq(Cat(dq_i[1][:8], sr_in)),
-            })
+            }),
+            sr_in_cnt.eq(sr_in_cnt - last_sink_width),
         )
 
         # FSM.
         self.fsm = fsm = FSM(reset_state="WAIT-CMD-DATA")
         fsm.act("WAIT-CMD-DATA",
+            NextValue(spi_clk_divisor_delayed, spi_clk_divisor),
             # Wait for CS and a CMD from the Core.
             If(cs_control.enable & sink.valid,
-                self.clkgen.en.eq(1),
-                # Load Shift Register Count/Data Out.
-                NextValue(sr_out_cnt, sink.len - sink.width),
-                NextValue(sr_in_cnt, sink.len),
-
+                self.clkgen.start.eq(1),
+                NextValue(last_sink_width, sink.width),
+                NextValue(last_dq_oe, sink.mask),
+                dq_oe.eq(sink.mask),
                 sr_out_load.eq(1),
+                sink.ready.eq(1),
+                If(sink.clk_div > 0,
+                    clkgen.div.eq(sink.clk_div),
+                    NextValue(spi_clk_divisor_delayed, sink.clk_div),
+                ),
                 # Start XFER.
                 NextState("XFER"),
             ),
@@ -205,34 +222,20 @@ class LiteSPIDDRPHYCore2(LiteXModule):
             sr_out_shift.eq(clkgen.negedge),
 
             # Shift Register Count Update/Check.
-            If(clkgen.posedge_reg2,
-                NextValue(sr_in_cnt, sr_in_cnt - sink.width),
-            ),
-            If(self.clkgen.negedge,
-                # End XFer.
-                If(sr_out_cnt == 0,
-                    NextState("XFER-END"),
-                ).Else(
-                    NextValue(sr_out_cnt, sr_out_cnt - sink.width),
+            If((self.clkgen.negedge != 0) & (sr_out_cnt == 0),
+                self.clkgen.en.eq(0),
+                NextState("XFER-END"),
+                If(no_read | (sr_in_cnt == 0) | ((clkgen.posedge_reg2 != 0) & (sr_in_cnt == last_sink_width)),
+                    NextState("SEND-STATUS-DATA"),
                 ),
             ),
 
         )
         fsm.act("XFER-END",
-            If(sr_in_cnt == 0,
-               sink.ready.eq(1),
+            sr_in_shift.eq(clkgen.posedge_reg2),
+            If((clkgen.posedge_reg2 != 0) & (sr_in_cnt == last_sink_width),
                 # Send Status/Data to Core.
                 NextState("SEND-STATUS-DATA"),
-            ).Else(
-                sr_in_shift.eq(clkgen.posedge_reg2),
-                If(clkgen.posedge_reg2,
-                    NextValue(sr_in_cnt, sr_in_cnt - sink.width),
-                    If(sr_in_cnt == sink.width,
-                       sink.ready.eq(1),
-                       # Send Status/Data to Core.
-                       NextState("SEND-STATUS-DATA"),
-                    ),
-                ),
             ),
         )
         self.comb += source.data.eq(sr_in)

--- a/litespi/phy/generic_ddr_with_clk.py
+++ b/litespi/phy/generic_ddr_with_clk.py
@@ -1,0 +1,245 @@
+#
+# This file is part of LiteSPI
+#
+# Copyright (c) 2020-2021 Antmicro <www.antmicro.com>
+# Copyright (c) 2021 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2025 Fin Maaß <f.maass@vogl-electronic.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+
+from litex.gen import *
+
+from litespi.common import *
+from litespi.clkgen import LiteSPIClkGen2
+from litespi.cscontrol import LiteSPICSControl
+
+from litex.soc.interconnect import stream
+from litex.soc.interconnect.csr import *
+
+from litex.build.io import DDRTristate
+
+
+# LiteSPI PHY Core ---------------------------------------------------------------------------------
+
+class LiteSPIDDRPHYCore2(LiteXModule):
+    """LiteSPI PHY instantiator
+
+    The ``LiteSPIPHYCore`` class provides a generic PHY that can be connected to the ``LiteSPICore``.
+
+    It supports single/dual/quad/octal output reads from the flash chips.
+
+    You can use this class only with devices that supports the DDR primitives.
+
+    Parameters
+    ----------
+    pads : Object
+        SPI pads description.
+
+    flash : SpiNorFlashModule
+        SpiNorFlashModule configuration object.
+
+    default_divisor : int
+        Default frequency divisor for clkgen.
+
+    Attributes
+    ----------
+    source : Endpoint(spi_phy2core_layout), out
+        Data stream.
+
+    sink : Endpoint(spi_core2phy_layout), in
+        Control stream.
+
+    cs : Signal(), in
+        Flash CS signal.
+
+    clk_divisor : CSRStorage
+        Register which holds a clock divisor value applied to clkgen.
+    """
+    def __init__(self, pads, flash, clock_domain, default_divisor=9, extra_latency=0, **kwargs):
+        self.source           = source = stream.Endpoint(spi_phy2core_layout)
+        self.sink             = sink   = stream.Endpoint(spi_core2phy_layout)
+        self.cs               = Signal().like(pads.cs_n)
+        self._spi_clk_divisor = spi_clk_divisor = Signal(len(sink.clk_div))
+
+        self._default_divisor = default_divisor
+
+        self.clk_divisor      = clk_divisor = CSRStorage(len(sink.clk_div), reset=self._default_divisor)
+
+        # # #
+
+        # Resynchronize CSR Clk Divisor to LiteSPI Clk Domain.
+        self.submodules += ResyncReg(clk_divisor.storage, spi_clk_divisor, clock_domain)
+
+        if hasattr(pads, "miso"):
+            bus_width = 1
+            dq_len    = 2
+            pads.dq   = [pads.mosi, pads.miso]
+        else:
+            bus_width = dq_len = len(pads.dq) if not hasattr(pads.dq, "o") else len(pads.dq.o)
+
+        assert bus_width in [1, 2, 4, 8]
+
+        if flash:
+            # Check if number of pads matches configured mode.
+            assert flash.check_bus_width(bus_width)
+            assert not flash.ddr
+
+        # Clock Generator.
+        self.clkgen = clkgen = LiteSPIClkGen2(pads, div_width=len(sink.clk_div), extra_latency=2*extra_latency)
+
+        # CS control.
+        self.cs_control = cs_control = LiteSPICSControl(pads, self.cs, **kwargs)
+
+        spi_clk_divisor_delayed = Signal(len(sink.clk_div))
+
+        # Only Clk Divisor when not active or when set by core.
+        self.sync += If(~clkgen.en, spi_clk_divisor_delayed.eq(spi_clk_divisor))
+
+        self.comb += [
+            If(sink.valid & (sink.clk_div > 0),
+                clkgen.div.eq(sink.clk_div),
+            ).Else(
+                clkgen.div.eq(spi_clk_divisor_delayed),
+            )
+        ]
+
+        dq_o  = Array([Signal(dq_len, name="dq_o"+str(n)) for n in range(2)])
+        dq_i  = Array([Signal(dq_len, name="dq_i"+str(n)) for n in range(2)])
+        dq_oe = Signal(dq_len)
+
+        self.specials += DDRTristate(
+            io  = pads.dq,
+            o1  =  dq_o[0],  o2 =  dq_o[1],
+            i1  =  dq_i[0],  i2 =  dq_i[1],
+            oe1 =  dq_oe,
+        )
+
+        # Data Shift Registers.
+        sr_out_cnt   = Signal(len(sink.len), reset_less=True)
+        sr_in_cnt    = Signal(len(sink.len), reset_less=True)
+        sr_out_load  = Signal()
+        sr_out_shift = Signal(2)
+        sr_out       = Signal(len(sink.data), reset_less=True)
+        sr_out_shifted = Signal(len(sink.data), reset_less=True)
+        sr_out_loaded  = Signal(len(sink.data), reset_less=True)
+        sr_in_shift  = Signal(2)
+        sr_in        = Signal(len(sink.data), reset_less=True)
+
+        # Data Out Shift.
+        self.comb += [
+            dq_oe.eq(sink.mask),
+            Case(sink.width, {
+                1:  dq_o[1].eq(sr_out[-1:]),
+                2:  dq_o[1].eq(sr_out[-2:]),
+                4:  dq_o[1].eq(sr_out[-4:]),
+                8:  dq_o[1].eq(sr_out[-8:]),
+            }),
+            sr_out_shifted.eq(sr_out << sink.width),
+            sr_out_loaded.eq(sink.data << (len(sink.data) - sink.len))
+        ]
+        self.sync += If(sr_out_load,
+            sr_in.eq(0),
+            sr_out.eq(sr_out_loaded),
+            Case(sink.width, {
+                1:  dq_o[0].eq(sr_out_loaded[-1:]),
+                2:  dq_o[0].eq(sr_out_loaded[-2:]),
+                4:  dq_o[0].eq(sr_out_loaded[-4:]),
+                8:  dq_o[0].eq(sr_out_loaded[-8:]),
+            }),
+        ).Elif(sr_out_shift[0],
+            Case(sink.width, {
+                1:  dq_o[0].eq(sr_out_shifted[-1:]),
+                2:  dq_o[0].eq(sr_out_shifted[-2:]),
+                4:  dq_o[0].eq(sr_out_shifted[-4:]),
+                8:  dq_o[0].eq(sr_out_shifted[-8:]),
+            }),
+            sr_out.eq(sr_out_shifted),
+        ).Elif(sr_out_shift[1],
+            dq_o[0].eq(dq_o[1]),
+            sr_out.eq(sr_out_shifted),
+        ).Else(
+            dq_o[0].eq(dq_o[1]),
+        )
+
+        # Data In Shift.
+        self.sync += If(sr_in_shift[0],
+            Case(sink.width, {
+                1 : sr_in.eq(Cat(dq_i[0][1],  sr_in)), # 1: pads.miso
+                2 : sr_in.eq(Cat(dq_i[0][:2], sr_in)),
+                4 : sr_in.eq(Cat(dq_i[0][:4], sr_in)),
+                8 : sr_in.eq(Cat(dq_i[0][:8], sr_in)),
+            })
+        ).Elif(sr_in_shift[1],
+            Case(sink.width, {
+                1 : sr_in.eq(Cat(dq_i[1][1],  sr_in)), # 1: pads.miso
+                2 : sr_in.eq(Cat(dq_i[1][:2], sr_in)),
+                4 : sr_in.eq(Cat(dq_i[1][:4], sr_in)),
+                8 : sr_in.eq(Cat(dq_i[1][:8], sr_in)),
+            })
+        )
+
+        # FSM.
+        self.fsm = fsm = FSM(reset_state="WAIT-CMD-DATA")
+        fsm.act("WAIT-CMD-DATA",
+            # Wait for CS and a CMD from the Core.
+            If(cs_control.enable & sink.valid,
+                self.clkgen.en.eq(1),
+                # Load Shift Register Count/Data Out.
+                NextValue(sr_out_cnt, sink.len - sink.width),
+                NextValue(sr_in_cnt, sink.len),
+
+                sr_out_load.eq(1),
+                # Start XFER.
+                NextState("XFER"),
+            ),
+        )
+        fsm.act("XFER",
+            # Generate Clk.
+            self.clkgen.en.eq(1),
+
+            # Data In Shift.
+            sr_in_shift.eq(clkgen.posedge_reg2),
+
+            # Data Out Shift.
+            sr_out_shift.eq(clkgen.negedge),
+
+            # Shift Register Count Update/Check.
+            If(clkgen.posedge_reg2,
+                NextValue(sr_in_cnt, sr_in_cnt - sink.width),
+            ),
+            If(self.clkgen.negedge,
+                # End XFer.
+                If(sr_out_cnt == 0,
+                    NextState("XFER-END"),
+                ).Else(
+                    NextValue(sr_out_cnt, sr_out_cnt - sink.width),
+                ),
+            ),
+
+        )
+        fsm.act("XFER-END",
+            If(sr_in_cnt == 0,
+               sink.ready.eq(1),
+                # Send Status/Data to Core.
+                NextState("SEND-STATUS-DATA"),
+            ).Else(
+                sr_in_shift.eq(clkgen.posedge_reg2),
+                If(clkgen.posedge_reg2,
+                    NextValue(sr_in_cnt, sr_in_cnt - sink.width),
+                    If(sr_in_cnt == sink.width,
+                       sink.ready.eq(1),
+                       # Send Status/Data to Core.
+                       NextState("SEND-STATUS-DATA"),
+                    ),
+                ),
+            ),
+        )
+        self.comb += source.data.eq(sr_in)
+        fsm.act("SEND-STATUS-DATA",
+            # Send Data In to Core and return to WAIT when accepted.
+            source.valid.eq(1),
+            If(source.ready,
+                NextState("WAIT-CMD-DATA"),
+            )
+        )


### PR DESCRIPTION
- add ddr variant with clk divider
- change sdr variant to use a compatible clk divider with the ddr variant
- add clk drivider csr per core module
- extra_latency: adds support for sdr phy, for ddr phy more granular (0,5 steps)
- cs timer: moves delay to start, when cs is not active, so in a lot of cases when using it, we don't have to wait anymore