### PR TITLE
modules: describe IS25LP128 quad-enable sequence

### DIFF
--- a/litespi/modules/generated_modules.py
+++ b/litespi/modules/generated_modules.py
@@ -2609,6 +2609,7 @@ class IS25LP128(SpiNorFlashModule):
         SpiNorFlashOpCodes.PP_1_1_2,
     ]
     dummy_bits = 8
+    quad_enable = "wrsr_sr1_bit6"
 
 
 class IS25LP128D(SpiNorFlashModule):

--- a/test/test_flash_module.py
+++ b/test/test_flash_module.py
@@ -7,6 +7,7 @@
 import unittest
 
 from litespi.spi_nor_flash_module import SpiNorFlashModule
+from litespi.modules import IS25LP128
 from litespi.opcodes import SpiNorFlashOpCodes as Codes
 from litespi.ids import SpiNorFlashManufacturerIDs
 
@@ -82,6 +83,11 @@ class TestFlashModule(unittest.TestCase):
         # Nonsupported mode
         with self.assertRaises(ValueError):
             chip = self.GoodDummyChip(Codes.READ_1_8_8)
+
+    def test_is25lp128_quad_enable(self):
+        chip = IS25LP128(Codes.READ_1_1_4)
+
+        self.assertEqual(chip.quad_enable, "wrsr_sr1_bit6")
 
     def test_meta_sizes(self):
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
Companion to https://github.com/enjoy-digital/litex/pull/2516 and https://github.com/enjoy-digital/litex/issues/2064.

The IS25LP128 stores its Quad Enable bit in status register 1 bit 6 and expects a two-byte WRSR transaction: the command followed by one status byte. Describe this with the wrsr_sr1_bit6 module metadata so LiteX can select the correct flash-specific initialization sequence.

This PR should be merged after the companion LiteX support. Older LiteX code would otherwise continue through the legacy three-byte path.

Validated with:

- pytest -q
- Combined ULX3S target generation using both branches.
- Complete RISC-V BIOS compilation using the generated metadata.
- git diff --check