### PR TITLE
phy/generic_ddr: Validate timing and fix portable tristate use

### DIFF
--- a/litespi/clkgen.py
+++ b/litespi/clkgen.py
@@ -30,6 +30,7 @@ class DDRLiteSPIClkGen(LiteXModule):
     def __init__(self, pads):
         self.en         = en         = Signal()
 
+        # Keep SCK rising/falling edges aligned with sys rising/falling edges respectively.
         self.specials += DDROutput(i1=en, i2=0, o=pads.clk)
 
 

--- a/litespi/phy/generic_ddr.py
+++ b/litespi/phy/generic_ddr.py
@@ -41,6 +41,9 @@ class LiteSPIDDRPHYCore(LiteXModule):
     flash : SpiNorFlashModule
         SpiNorFlashModule configuration object.
 
+    extra_latency : int
+        Additional input pipeline latency. Each unit extends the pipeline drain by two sys cycles.
+
     Attributes
     ----------
     source : Endpoint(spi_phy2core_layout), out
@@ -77,6 +80,7 @@ class LiteSPIDDRPHYCore(LiteXModule):
         # CS control.
         self.cs_control = cs_control = LiteSPICSControl(pads, self.cs, **kwargs)
 
+        # Lane 0 is aligned with SCK high/rising and lane 1 with SCK low/falling.
         dq_o  = Array([Signal(len(dq)) for _ in range(2)])
         dq_i  = Array([Signal(len(dq)) for _ in range(2)])
         dq_oe = Signal(len(dq))
@@ -95,6 +99,7 @@ class LiteSPIDDRPHYCore(LiteXModule):
         sr_out       = Signal(len(sink.data), reset_less=True)
         sr_in_shift  = Signal()
         sr_in        = Signal(len(sink.data), reset_less=True)
+        input_pipeline = 2 + 2*extra_latency
 
         # Data Out Shift.
         self.comb += [
@@ -158,7 +163,8 @@ class LiteSPIDDRPHYCore(LiteXModule):
             NextValue(sr_cnt, sr_cnt - sink.width),
             # End XFer.
             If(sr_cnt == 0,
-                NextValue(sr_cnt, (2 + 2*extra_latency)*sink.width), # FIXME: Explain magic numbers.
+                # Drain the IDDR and fabric input pipeline after the final SCK edge.
+                NextValue(sr_cnt, input_pipeline*sink.width),
                 NextState("XFER-END"),
             ),
         )

--- a/litespi/phy/generic_ddr.py
+++ b/litespi/phy/generic_ddr.py
@@ -59,9 +59,10 @@ class LiteSPIDDRPHYCore(LiteXModule):
 
         if hasattr(pads, "miso"):
             bus_width = 1
-            pads.dq   = [pads.mosi, pads.miso]
+            dq        = Cat(pads.mosi, pads.miso)
         else:
             bus_width = len(pads.dq)
+            dq        = pads.dq
 
         assert bus_width in [1, 2, 4, 8]
 
@@ -76,14 +77,14 @@ class LiteSPIDDRPHYCore(LiteXModule):
         # CS control.
         self.cs_control = cs_control = LiteSPICSControl(pads, self.cs, **kwargs)
 
-        dq_o  = Array([Signal(len(pads.dq)) for _ in range(2)])
-        dq_i  = Array([Signal(len(pads.dq)) for _ in range(2)])
-        dq_oe = Array([Signal(len(pads.dq)) for _ in range(2)])
+        dq_o  = Array([Signal(len(dq)) for _ in range(2)])
+        dq_i  = Array([Signal(len(dq)) for _ in range(2)])
+        dq_oe = Signal(len(dq))
 
         self.specials += DDRTristate(
-            io  = pads.dq,
+            io  = dq,
             o1  =  dq_o[0],  o2 =  dq_o[1],
-            oe1 = dq_oe[0], oe2 = dq_oe[1],
+            oe1 = dq_oe,
             i1  =  dq_i[0],  i2 =  dq_i[1]
         )
 
@@ -97,7 +98,7 @@ class LiteSPIDDRPHYCore(LiteXModule):
 
         # Data Out Shift.
         self.comb += [
-            dq_oe[1].eq(sink.mask),
+            dq_oe.eq(sink.mask),
             Case(sink.width, {
                 1:  dq_o[1].eq(sr_out[-1:]),
                 2:  dq_o[1].eq(sr_out[-2:]),
@@ -109,7 +110,6 @@ class LiteSPIDDRPHYCore(LiteXModule):
             sr_out.eq(sink.data << (len(sink.data) - sink.len))
         )
         self.sync += If(sr_out_shift,
-            dq_oe[0].eq(dq_oe[1]),
             dq_o[0].eq(dq_o[1]),
             Case(sink.width, {
                 1 : sr_out.eq(Cat(Signal(1), sr_out)),

--- a/test/test_phy_ddr.py
+++ b/test/test_phy_ddr.py
@@ -1,0 +1,256 @@
+#
+# This file is part of LiteSPI.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+
+from litex.build.io import DDROutput, DDRTristate
+
+from litespi.phy.generic_ddr import LiteSPIDDRPHYCore
+
+
+# DDR I/O simulation -------------------------------------------------------------------------------
+
+class _DDRBus:
+    def __init__(self, width, input_latency=0):
+        self.i             = Signal(width)
+        self.o             = Signal(width)
+        self.oe            = Signal(width)
+        self.input_latency = input_latency
+
+
+class _SimDDROutputImpl(Module):
+    def __init__(self, dr):
+        i1 = Signal.like(dr.i1)
+        i2 = Signal.like(dr.i2)
+
+        self.sync += [
+            i1.eq(dr.i1),
+            i2.eq(dr.i2),
+        ]
+        self.comb += dr.o.eq(Mux(dr.clk, i1, i2))
+
+
+class _SimDDROutput:
+    @staticmethod
+    def lower(dr):
+        return _SimDDROutputImpl(dr)
+
+
+class _SimDDRTristateImpl(Module):
+    def __init__(self, dr, bus):
+        o1  = Signal.like(dr.o1)
+        o2  = Signal.like(dr.o2)
+        oe1 = Signal.like(dr.oe1)
+        oe2 = Signal.like(dr.oe1)
+        i1_pipeline = [Signal.like(dr.i1) for _ in range(1 + 2*bus.input_latency)]
+        i2_pipeline = [Signal.like(dr.i2) for _ in range(1 + 2*bus.input_latency)]
+
+        self.sync += [
+            o1.eq(dr.o1),
+            o2.eq(dr.o2),
+            oe1.eq(dr.oe1),
+            i1_pipeline[0].eq(bus.i),
+            dr.i1.eq(i1_pipeline[-1]),
+            dr.i2.eq(i2_pipeline[-1]),
+        ]
+        for i in range(1, len(i1_pipeline)):
+            self.sync += i1_pipeline[i].eq(i1_pipeline[i - 1])
+            self.sync += i2_pipeline[i].eq(i2_pipeline[i - 1])
+        self.sync.sys_n += i2_pipeline[0].eq(bus.i)
+
+        if dr.oe2 is None:
+            self.comb += bus.oe.eq(oe1)
+        else:
+            self.sync += oe2.eq(dr.oe2)
+            self.comb += bus.oe.eq(Mux(dr.clk, oe1, oe2))
+
+        self.comb += bus.o.eq(Mux(dr.clk, o1, o2))
+
+
+class _SimDDRTristate:
+    bus = None
+
+    @classmethod
+    def lower(cls, dr):
+        return _SimDDRTristateImpl(dr, cls.bus)
+
+
+# DDR PHY DUT --------------------------------------------------------------------------------------
+
+class _LiteSPIDDRPHYDUT(Module):
+    def __init__(self, width, extra_latency):
+        self.clock_domains.cd_sys_n = ClockDomain(reset_less=True)
+
+        if width == 1:
+            self.pads = pads = Record([
+                ("clk",  1),
+                ("cs_n", 1),
+                ("mosi", 1),
+                ("miso", 1),
+            ])
+            io_width = 2
+        else:
+            self.pads = pads = Record([
+                ("clk",  1),
+                ("cs_n", 1),
+                ("dq",   width),
+            ])
+            io_width = width
+
+        self.bus = _DDRBus(io_width, input_latency=extra_latency)
+        self.submodules.phy = LiteSPIDDRPHYCore(
+            pads           = pads,
+            flash          = None,
+            extra_latency  = extra_latency,
+            cs_delay       = 0,
+            with_sdr_cs    = False,
+        )
+
+
+# DDR PHY Tests ------------------------------------------------------------------------------------
+
+class TestLiteSPIDDRPHY(unittest.TestCase):
+    clocks = {
+        "sys"   : 10,
+        "sys_n" : (10, 5),
+    }
+
+    special_overrides = {
+        DDROutput   : _SimDDROutput,
+        DDRTristate : _SimDDRTristate,
+    }
+
+    @staticmethod
+    def _transfer(phy, data, length, width, mask):
+        yield phy.sink.data.eq(data)
+        yield phy.sink.len.eq(length)
+        yield phy.sink.width.eq(width)
+        yield phy.sink.mask.eq(mask)
+        yield phy.sink.valid.eq(1)
+
+        while not (yield phy.sink.ready):
+            yield
+
+        yield phy.sink.valid.eq(0)
+        while not (yield phy.source.valid):
+            yield
+
+        result = yield phy.source.data
+        yield
+        return result
+
+    def _run(self, dut, generators):
+        _SimDDRTristate.bus = dut.bus
+        run_simulation(
+            dut,
+            generators,
+            clocks            = self.clocks,
+            special_overrides = self.special_overrides,
+        )
+
+    def test_output_data_and_clock_edges(self):
+        for width in [2, 4, 8]:
+            with self.subTest(width=width):
+                dut    = _LiteSPIDDRPHYDUT(width=width, extra_latency=0)
+                phy    = dut.phy
+                groups = [i & (2**width - 1) for i in range(1, 32//width + 1)]
+                data   = 0
+                trace  = []
+
+                for group in groups:
+                    data = (data << width) | group
+
+                def monitor():
+                    yield "passive"
+                    while True:
+                        yield
+                        if (yield dut.pads.clk):
+                            trace.append(((yield dut.bus.oe), (yield dut.bus.o)))
+
+                def generator():
+                    yield phy.source.ready.eq(1)
+                    yield phy.cs.eq(1)
+                    for _ in range(3):
+                        yield
+
+                    yield from self._transfer(
+                        phy    = phy,
+                        data   = data,
+                        length = 32,
+                        width  = width,
+                        mask   = 1 if width == 1 else 2**width - 1,
+                    )
+
+                    yield phy.cs.eq(0)
+                    for _ in range(3):
+                        yield
+
+                    self.assertEqual((yield dut.pads.clk), 0)
+
+                self._run(dut, {
+                    "sys"   : generator(),
+                    "sys_n" : monitor(),
+                })
+
+                output_mask = 1 if width == 1 else 2**width - 1
+                self.assertEqual(len(trace), 32//width)
+                self.assertEqual([oe & output_mask for oe, _ in trace], [output_mask]*len(trace))
+                self.assertEqual([data & (2**width - 1) for _, data in trace], groups)
+
+    def test_input_data_with_extra_latency(self):
+        for width in [2, 4, 8]:
+            for extra_latency in [0, 1]:
+                with self.subTest(width=width, extra_latency=extra_latency):
+                    dut      = _LiteSPIDDRPHYDUT(width=width, extra_latency=extra_latency)
+                    phy      = dut.phy
+                    expected = 0x12345678
+                    groups   = [
+                        (expected >> shift) & (2**width - 1)
+                        for shift in range(32 - width, -1, -width)
+                    ]
+                    edges    = []
+
+                    def flash_model():
+                        yield "passive"
+                        index = 0
+                        value = groups[index] << (1 if width == 1 else 0)
+                        yield dut.bus.i.eq(value)
+
+                        while True:
+                            yield
+                            if (yield dut.pads.clk):
+                                edges.append(1)
+                                index += 1
+                                if index < len(groups):
+                                    value = groups[index] << (1 if width == 1 else 0)
+                                    yield dut.bus.i.eq(value)
+
+                    def generator():
+                        yield phy.source.ready.eq(1)
+                        yield phy.cs.eq(1)
+                        for _ in range(3):
+                            yield
+
+                        result = yield from self._transfer(
+                            phy    = phy,
+                            data   = 0,
+                            length = 32,
+                            width  = width,
+                            mask   = 0,
+                        )
+                        self.assertEqual(result, expected)
+
+                    self._run(dut, {
+                        "sys"   : generator(),
+                        "sys_n" : flash_model(),
+                    })
+                    self.assertEqual(len(edges), 32//width)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_phy_ddr.py
+++ b/test/test_phy_ddr.py
@@ -283,6 +283,74 @@ class TestLiteSPIDDRPHY(unittest.TestCase):
                     })
                     self.assertEqual(len(edges), 32//width)
 
+    def test_command_address_read_turnaround(self):
+        dut          = _LiteSPIDDRPHYDUT(width=4, extra_latency=1)
+        phy          = dut.phy
+        command      = 0x6b
+        address      = 0x123456
+        expected     = 0x89abcdef
+        input_groups = [(expected >> shift) & 0xf for shift in range(28, -1, -4)]
+        output_bits  = []
+        input_edges  = []
+        read_active  = [False]
+
+        def flash_model():
+            yield "passive"
+            input_index = 0
+
+            while True:
+                if read_active[0] and input_index == 0:
+                    yield dut.bus.i.eq(input_groups[0])
+
+                yield
+                if not (yield dut.pads.clk):
+                    continue
+
+                if (yield dut.bus.oe) & 0x1:
+                    output_bits.append((yield dut.bus.o) & 0x1)
+                elif read_active[0]:
+                    input_edges.append(1)
+                    input_index += 1
+                    if input_index < len(input_groups):
+                        yield dut.bus.i.eq(input_groups[input_index])
+
+        def generator():
+            yield phy.source.ready.eq(1)
+            yield phy.cs.eq(1)
+            for _ in range(3):
+                yield
+
+            yield from self._transfer(phy, command, 8, 1, 0x1)
+            self.assertEqual((yield dut.pads.cs_n), 0)
+
+            yield from self._transfer(phy, address, 24, 1, 0x1)
+            self.assertEqual((yield dut.pads.cs_n), 0)
+
+            read_active[0] = True
+            yield
+            result = yield from self._transfer(phy, 0, 32, 4, 0)
+            self.assertEqual(result, expected)
+
+            yield phy.cs.eq(0)
+            for _ in range(3):
+                yield
+
+            self.assertEqual((yield dut.pads.clk), 0)
+            self.assertEqual((yield dut.pads.cs_n), 1)
+
+        self._run(dut, {
+            "sys"   : generator(),
+            "sys_n" : flash_model(),
+        })
+
+        output = 0
+        for bit in output_bits:
+            output = (output << 1) | bit
+
+        self.assertEqual(len(output_bits), 32)
+        self.assertEqual(output, (command << 24) | address)
+        self.assertEqual(len(input_edges), 8)
+
 
 class TestLiteSPIDDRPHYElaboration(unittest.TestCase):
     @staticmethod

--- a/test/test_phy_ddr.py
+++ b/test/test_phy_ddr.py
@@ -49,6 +49,7 @@ class _SimDDRTristateImpl(Module):
         o2  = Signal.like(dr.o2)
         oe1 = Signal.like(dr.oe1)
         oe2 = Signal.like(dr.oe1)
+        # Match the registered DDR input path and model optional platform I/O latency.
         i1_pipeline = [Signal.like(dr.i1) for _ in range(1 + 2*bus.input_latency)]
         i2_pipeline = [Signal.like(dr.i2) for _ in range(1 + 2*bus.input_latency)]
 
@@ -145,6 +146,7 @@ class _LiteSPIDDRPHYElaborationDUT(Module):
 # DDR PHY Tests ------------------------------------------------------------------------------------
 
 class TestLiteSPIDDRPHY(unittest.TestCase):
+    # sys_n provides the falling half-cycle used by the behavioral DDR input model.
     clocks = {
         "sys"   : 10,
         "sys_n" : (10, 5),

--- a/test/test_phy_ddr.py
+++ b/test/test_phy_ddr.py
@@ -9,6 +9,8 @@ import unittest
 from migen import *
 
 from litex.build.io import DDROutput, DDRTristate
+from litex.build.lattice.platform import LatticePlatform
+from litex.build.xilinx.platform import XilinxPlatform
 
 from litespi.phy.generic_ddr import LiteSPIDDRPHYCore
 
@@ -112,6 +114,34 @@ class _LiteSPIDDRPHYDUT(Module):
         )
 
 
+class _LiteSPIDDRPHYElaborationDUT(Module):
+    def __init__(self, width):
+        self.clock_domains.cd_sys = ClockDomain()
+
+        if width == 1:
+            self.pads = pads = Record([
+                ("clk",  1),
+                ("cs_n", 1),
+                ("mosi", 1),
+                ("miso", 1),
+            ])
+            pads_ios = {pads.clk, pads.cs_n, pads.mosi, pads.miso}
+        else:
+            self.pads = pads = Record([
+                ("clk",  1),
+                ("cs_n", 1),
+                ("dq",   width),
+            ])
+            pads_ios = {pads.clk, pads.cs_n, pads.dq}
+
+        self.submodules.phy = LiteSPIDDRPHYCore(
+            pads     = pads,
+            flash    = None,
+            cs_delay = 0,
+        )
+        self.ios = pads_ios | {self.cd_sys.clk, self.cd_sys.rst}
+
+
 # DDR PHY Tests ------------------------------------------------------------------------------------
 
 class TestLiteSPIDDRPHY(unittest.TestCase):
@@ -154,7 +184,7 @@ class TestLiteSPIDDRPHY(unittest.TestCase):
         )
 
     def test_output_data_and_clock_edges(self):
-        for width in [2, 4, 8]:
+        for width in [1, 2, 4, 8]:
             with self.subTest(width=width):
                 dut    = _LiteSPIDDRPHYDUT(width=width, extra_latency=0)
                 phy    = dut.phy
@@ -203,7 +233,7 @@ class TestLiteSPIDDRPHY(unittest.TestCase):
                 self.assertEqual([data & (2**width - 1) for _, data in trace], groups)
 
     def test_input_data_with_extra_latency(self):
-        for width in [2, 4, 8]:
+        for width in [1, 2, 4, 8]:
             for extra_latency in [0, 1]:
                 with self.subTest(width=width, extra_latency=extra_latency):
                     dut      = _LiteSPIDDRPHYDUT(width=width, extra_latency=extra_latency)
@@ -250,6 +280,28 @@ class TestLiteSPIDDRPHY(unittest.TestCase):
                         "sys_n" : flash_model(),
                     })
                     self.assertEqual(len(edges), 32//width)
+
+
+class TestLiteSPIDDRPHYElaboration(unittest.TestCase):
+    @staticmethod
+    def _get_verilog(platform, width):
+        dut = _LiteSPIDDRPHYElaborationDUT(width=width)
+        return str(platform.get_verilog(dut, ios=dut.ios))
+
+    def test_lattice_nx_quad_io(self):
+        platform = LatticePlatform("LIFCL-40", [], toolchain="radiant")
+        verilog  = self._get_verilog(platform, width=4)
+
+        self.assertIn("ODDRX1", verilog)
+        self.assertIn("IDDRX1", verilog)
+        self.assertIn("OFD1P3BX", verilog)
+
+    def test_xilinx_7series_single_io(self):
+        platform = XilinxPlatform("xc7a35t-csg324-1", [], toolchain="vivado")
+        verilog  = self._get_verilog(platform, width=1)
+
+        self.assertIn("ODDR", verilog)
+        self.assertIn("IDDR", verilog)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add pin-level simulation of the generic DDR PHY and its DDR I/O primitives;
- preserve the established SCK polarity and DDR data-lane phase;
- use a single registered output-enable path supported by all `DDRTristate` lowerings;
- restore 1x elaboration by representing separate MOSI/MISO pads as a Migen value;
- document the SCK/data edge contract and input-pipeline drain; and
- check generated Xilinx 7-Series and CrossLink-NX primitives.

## Background
This is a fresh implementation following the investigation of #60 and @danc86 hardware report on CrossLink-NX/GD25LQ128D. That PR changed SCK polarity, input capture lane, data staging, output-enable staging and clock control together, and the affected system no longer booted with `extra_latency=1`.

This series starts from current master and deliberately keeps the known-working polarity and data-lane mapping. It only removes the second output-enable lane: SPI direction is constant over both halves of SCK, and current CrossLink-NX/Efinix `DDRTristate` lowerings require the single-edge enable path.

## Validation
- `pytest -q`: 12 passed, 44 subtests passed.
- Pin-level transfers at 1x, 2x, 4x and 8x.
- Exact SCK edge count, serialized output ordering and captured input data.
- Input-pipeline compensation with `extra_latency=0` and `extra_latency=1`.
- Command + address + quad-read turnaround while CS remains asserted.
- Clean SCK/CS shutdown.
- Verilog elaboration with Xilinx 7-Series and CrossLink-NX DDR primitives.
- A deliberate #60-style SCK polarity flip is rejected by the new edge-contract regression test for every bus width.

Hardware confirmation is still requested on the original CrossLink-NX/GD25LQ128D `extra_latency=1` configuration and on an `extra_latency=0` Xilinx 7-Series configuration before merge.

Supersedes #60.