### PR TITLE
phy/generic_ddr: Add configurable SCK divider

### DIFF
--- a/litespi/clkgen.py
+++ b/litespi/clkgen.py
@@ -22,16 +22,110 @@ class DDRLiteSPIClkGen(LiteXModule):
     pads : Object
         SPI pads description.
 
+    div_width : int
+        Width of the ``div`` input.
+
+    extra_latency : int or float
+        Additional input latency in half-system-clock steps.
+
     Attributes
     ----------
-    en : Signal(), in
-        Clock enable input, output clock will be generated if set to 1, 0 resets the core.
-    """
-    def __init__(self, pads):
-        self.en         = en         = Signal()
+    div : Signal(), in
+        Clock divisor. SCK frequency is ``sys_clk_freq/div``.
 
-        # Keep SCK rising/falling edges aligned with sys rising/falling edges respectively.
-        self.specials += DDROutput(i1=en, i2=0, o=pads.clk)
+    en : Signal(), in
+        Keep the clock generator active.
+
+    start : Signal(), in
+        Start a transfer and latch ``div``.
+
+    posedge : Signal(), out
+        Indicates an SCK rising edge at the current system rising edge.
+
+    negedge : Signal(2), out
+        Indicates an SCK falling edge before lane 0 or between lanes 0 and 1.
+
+    sample : Signal(), out
+        Delayed ``posedge`` used to capture the registered DQ inputs.
+    """
+    def __init__(self, pads, div_width=8, extra_latency=0):
+        self.div      = div      = Signal(div_width)
+        self.en       = en       = Signal()
+        self.start    = start    = Signal()
+        self.posedge  = posedge  = Signal()
+        self.negedge  = negedge  = Signal(2)
+        self.sample   = sample   = Signal()
+        self.clk      = clk      = Signal(2)
+
+        extra_latency_cycles = int(2*extra_latency)
+        if (extra_latency < 0) or (extra_latency_cycles != 2*extra_latency):
+            raise ValueError("DDR PHY extra_latency must be a non-negative multiple of 0.5")
+
+        active          = Signal()
+        level           = Signal(reset=1)
+        remaining       = Signal(div_width, reset=1)
+        div_latched     = Signal(div_width, reset=1)
+        div_start       = Signal(div_width)
+        slot1_level     = Signal()
+        slot1_remaining = Signal(div_width)
+        next_level      = Signal()
+        next_remaining  = Signal(div_width)
+
+        self.comb += div_start.eq(Mux(div == 0, 1, div))
+
+        # Consume two SCK half-cycles per system cycle.
+        self.comb += [
+            slot1_level.eq(level),
+            slot1_remaining.eq(remaining - 1),
+            If(remaining == 1,
+                slot1_level.eq(~level),
+                slot1_remaining.eq(div_latched),
+            ),
+            next_level.eq(slot1_level),
+            next_remaining.eq(slot1_remaining - 1),
+            If(slot1_remaining == 1,
+                next_level.eq(~slot1_level),
+                next_remaining.eq(div_latched),
+            ),
+            clk[0].eq(active & level),
+            clk[1].eq(active & slot1_level),
+        ]
+
+        # Rising edges stay aligned to system rising edges. Falling edges occur either at the
+        # beginning of lane 0 for even divisors or between lanes 0/1 for odd divisors.
+        self.comb += [
+            posedge.eq(active &  level & (remaining == div_latched)),
+            negedge[0].eq(active & ~level & (remaining == div_latched)),
+            negedge[1].eq(active &  level & (remaining == 1)),
+        ]
+
+        self.sync += If(start,
+            active.eq(1),
+            level.eq(1),
+            remaining.eq(div_start),
+            div_latched.eq(div_start),
+        ).Elif(active,
+            If(en,
+                level.eq(next_level),
+                remaining.eq(next_remaining),
+            ).Else(
+                active.eq(0),
+                level.eq(1),
+                remaining.eq(div_latched),
+            )
+        )
+
+        # Delay input captures through the IDDR/fabric pipeline. Half-step latency values map to
+        # complete system cycles since the DDR path handles two half-cycles per system cycle.
+        sample_pipeline = Signal(2 + extra_latency_cycles)
+        self.sync += If(start,
+            sample_pipeline.eq(0),
+        ).Else(
+            sample_pipeline.eq(Cat(sample_pipeline[1:], posedge)),
+        )
+        self.comb += sample.eq(sample_pipeline[0])
+
+        self.specials += DDROutput(i1=clk[0], i2=clk[1], o=pads.clk)
 
 
 class LiteSPIClkGen(LiteXModule):

--- a/litespi/phy/generic.py
+++ b/litespi/phy/generic.py
@@ -61,7 +61,7 @@ class LiteSPIPHY(LiteXModule):
         if rate == "1:1":
             phy = LiteSPISDRPHYCore(pads, flash, device, clock_domain, **kwargs)
         if rate == "1:2":
-            phy = LiteSPIDDRPHYCore(pads, flash, **kwargs)
+            phy = LiteSPIDDRPHYCore(pads, flash, clock_domain=clock_domain, **kwargs)
 
         self.flash = flash
 

--- a/litespi/phy/generic_ddr.py
+++ b/litespi/phy/generic_ddr.py
@@ -2,19 +2,19 @@
 # This file is part of LiteSPI
 #
 # Copyright (c) 2020 Antmicro <www.antmicro.com>
+# Copyright (c) 2025-2026 Fin Maaß <f.maass@vogl-electronic.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *
 
 from litex.gen import *
 
-from litex.gen.genlib.misc import WaitTimer
-
 from litespi.common import *
 from litespi.clkgen import DDRLiteSPIClkGen
 from litespi.cscontrol import LiteSPICSControl
 
 from litex.soc.interconnect import stream
+from litex.soc.interconnect.csr import *
 
 from litex.build.io import DDRTristate
 
@@ -41,8 +41,14 @@ class LiteSPIDDRPHYCore(LiteXModule):
     flash : SpiNorFlashModule
         SpiNorFlashModule configuration object.
 
-    extra_latency : int
-        Additional input pipeline latency. Each unit extends the pipeline drain by two sys cycles.
+    extra_latency : int or float
+        Additional input pipeline latency. Each 0.5 adds one system-clock cycle.
+
+    clock_domain : str
+        Name of the LiteSPI clock domain.
+
+    default_divisor : int
+        Default SCK divisor.
 
     Attributes
     ----------
@@ -54,11 +60,27 @@ class LiteSPIDDRPHYCore(LiteXModule):
 
     cs : Signal(), in
         Flash CS signal.
+
+    clk_divisor : CSRStorage
+        Register which holds the default SCK divisor.
     """
-    def __init__(self, pads, flash, extra_latency=0, **kwargs):
-        self.source = source = stream.Endpoint(spi_phy2core_layout)
-        self.sink   = sink   = stream.Endpoint(spi_core2phy_layout)
-        self.cs              = Signal().like(pads.cs_n)
+    def __init__(self, pads, flash, extra_latency=0, clock_domain="sys", default_divisor=1, **kwargs):
+        self.source           = source = stream.Endpoint(spi_phy2core_layout)
+        self.sink             = sink   = stream.Endpoint(spi_core2phy_layout)
+        self.cs                        = Signal().like(pads.cs_n)
+        self._spi_clk_divisor = spi_clk_divisor = Signal(len(sink.clk_div))
+
+        self._default_divisor = default_divisor
+        self.clk_divisor      = CSRStorage(
+            len(sink.clk_div),
+            reset=self._default_divisor,
+            description="SPI clock divisor.",
+        )
+
+        # # #
+
+        # Resynchronize CSR Clock Divisor to LiteSPI Clock Domain.
+        self.submodules += ResyncReg(self.clk_divisor.storage, spi_clk_divisor, clock_domain)
 
         if hasattr(pads, "miso"):
             bus_width = 1
@@ -75,12 +97,17 @@ class LiteSPIDDRPHYCore(LiteXModule):
             assert not flash.ddr
 
         # Clock Generator.
-        self.clkgen = clkgen = DDRLiteSPIClkGen(pads)
+        self.clkgen = clkgen = DDRLiteSPIClkGen(
+            pads          = pads,
+            div_width     = len(sink.clk_div),
+            extra_latency = extra_latency,
+        )
+        self.comb += clkgen.div.eq(spi_clk_divisor)
 
         # CS control.
         self.cs_control = cs_control = LiteSPICSControl(pads, self.cs, **kwargs)
 
-        # Lane 0 is aligned with SCK high/rising and lane 1 with SCK low/falling.
+        # Lane 0 is output while sys is high and lane 1 while sys is low.
         dq_o  = Array([Signal(len(dq)) for _ in range(2)])
         dq_i  = Array([Signal(len(dq)) for _ in range(2)])
         dq_oe = Signal(len(dq))
@@ -93,98 +120,114 @@ class LiteSPIDDRPHYCore(LiteXModule):
         )
 
         # Data Shift Registers.
-        sr_cnt       = Signal(8, reset_less=True)
-        sr_out_load  = Signal()
-        sr_out_shift = Signal()
-        sr_out       = Signal(len(sink.data), reset_less=True)
-        sr_in_shift  = Signal()
-        sr_in        = Signal(len(sink.data), reset_less=True)
-        input_pipeline = 2 + 2*extra_latency
+        sr_out_cnt     = Signal(len(sink.len), reset_less=True)
+        sr_in_cnt      = Signal(len(sink.len), reset_less=True)
+        sr_out_load    = Signal()
+        sr_out_shift   = Signal()
+        sr_out         = Signal(len(sink.data), reset_less=True)
+        sr_out_shifted = Signal(len(sink.data), reset_less=True)
+        sr_in_shift    = Signal()
+        sr_in          = Signal(len(sink.data), reset_less=True)
+        current_data   = Signal(len(dq))
+        next_data      = Signal(len(dq))
+        last_width     = Signal.like(sink.width)
+        no_read        = Signal()
 
-        # Data Out Shift.
-        self.comb += [
-            dq_oe.eq(sink.mask),
-            Case(sink.width, {
-                1:  dq_o[1].eq(sr_out[-1:]),
-                2:  dq_o[1].eq(sr_out[-2:]),
-                4:  dq_o[1].eq(sr_out[-4:]),
-                8:  dq_o[1].eq(sr_out[-8:]),
-            })
-        ]
+        # Determine if the transfer only drives DQ and can skip the input-pipeline drain.
         self.sync += If(sr_out_load,
-            sr_out.eq(sink.data << (len(sink.data) - sink.len))
-        )
-        self.sync += If(sr_out_shift,
-            dq_o[0].eq(dq_o[1]),
             Case(sink.width, {
-                1 : sr_out.eq(Cat(Signal(1), sr_out)),
-                2 : sr_out.eq(Cat(Signal(2), sr_out)),
-                4 : sr_out.eq(Cat(Signal(4), sr_out)),
-                8 : sr_out.eq(Cat(Signal(8), sr_out)),
+                "default" : no_read.eq(0),
+                1 : no_read.eq(sink.mask[0]),
+                2 : no_read.eq(sink.mask[:2] == 0b11),
+                4 : no_read.eq(sink.mask[:4] == 0b1111),
+                8 : no_read.eq(sink.mask == 0xff),
             })
         )
 
-        # Data In Shift.
+        # Keep DQ stable until SCK falls. For odd divisors SCK falls between the two DDR lanes;
+        # for even divisors it falls at the beginning of lane 0.
+        self.comb += [
+            sr_out_shifted.eq(sr_out << last_width),
+            Case(last_width, {
+                1 : [current_data.eq(sr_out[-1:]), next_data.eq(sr_out_shifted[-1:])],
+                2 : [current_data.eq(sr_out[-2:]), next_data.eq(sr_out_shifted[-2:])],
+                4 : [current_data.eq(sr_out[-4:]), next_data.eq(sr_out_shifted[-4:])],
+                8 : [current_data.eq(sr_out[-8:]), next_data.eq(sr_out_shifted[-8:])],
+            }),
+            dq_o[0].eq(Mux(clkgen.negedge[0], next_data, current_data)),
+            dq_o[1].eq(Mux(clkgen.negedge != 0, next_data, current_data)),
+        ]
+
+        self.sync += If(sr_out_load,
+            sr_out.eq(sink.data << (len(sink.data) - sink.len)),
+            sr_in.eq(0),
+            sr_out_cnt.eq(sink.len),
+            sr_in_cnt.eq(sink.len),
+        ).Elif(sr_out_shift,
+            sr_out.eq(sr_out_shifted),
+            sr_out_cnt.eq(sr_out_cnt - last_width),
+        )
+
+        # SCK rising edges are always aligned to lane 0.
         self.sync += If(sr_in_shift,
-            Case(sink.width, {
+            Case(last_width, {
                 1 : sr_in.eq(Cat(dq_i[0][1],  sr_in)), # 1: pads.miso
                 2 : sr_in.eq(Cat(dq_i[0][:2], sr_in)),
                 4 : sr_in.eq(Cat(dq_i[0][:4], sr_in)),
                 8 : sr_in.eq(Cat(dq_i[0][:8], sr_in)),
-            })
+            }),
+            sr_in_cnt.eq(sr_in_cnt - last_width),
         )
 
         # FSM.
         self.fsm = fsm = FSM(reset_state="WAIT-CMD-DATA")
         fsm.act("WAIT-CMD-DATA",
-            # Stop Clk.
-            NextValue(clkgen.en, 0),
-            # Wait for CS and a CMD from the Core.
+            # Wait for CS and a command from the Core.
             If(cs_control.enable & sink.valid,
-                # Load Shift Register Count/Data Out.
-                NextValue(sr_cnt, sink.len - sink.width),
+                clkgen.start.eq(1),
+                NextValue(last_width, sink.width),
+                NextValue(dq_oe, sink.mask),
                 sr_out_load.eq(1),
-                # Start XFER.
-                NextState("XFER")
+                sink.ready.eq(1),
+                If(sink.clk_div > 0,
+                    clkgen.div.eq(sink.clk_div),
+                ),
+                NextState("XFER"),
             )
         )
-
         fsm.act("XFER",
-            # Generate Clk.
-            NextValue(clkgen.en, 1),
+            clkgen.en.eq(1),
 
-            # Data In Shift.
-            sr_in_shift.eq(1),
-
-            # Data Out Shift.
-            sr_out_shift.eq(1),
-
-            # Shift Register Count Update/Check.
-            NextValue(sr_cnt, sr_cnt - sink.width),
-            # End XFer.
-            If(sr_cnt == 0,
-                # Drain the IDDR and fabric input pipeline after the final SCK edge.
-                NextValue(sr_cnt, input_pipeline*sink.width),
-                NextState("XFER-END"),
+            # Capture registered input data after each delayed SCK rising edge.
+            If(clkgen.sample,
+                sr_in_shift.eq(1),
             ),
+
+            # Advance output data after each SCK falling edge.
+            If(clkgen.negedge != 0,
+                sr_out_shift.eq(1),
+                If(sr_out_cnt == last_width,
+                    clkgen.en.eq(0),
+                    NextValue(dq_oe, 0),
+                    If(no_read | (sr_in_cnt == 0) | (clkgen.sample & (sr_in_cnt == last_width)),
+                        NextState("SEND-STATUS-DATA"),
+                    ).Else(
+                        NextState("XFER-END"),
+                    )
+                )
+            )
         )
         fsm.act("XFER-END",
-            # Stop Clk.
-            NextValue(clkgen.en, 0),
-
-            # Data In Shift.
-            sr_in_shift.eq(1),
-
-            # Shift Register Count Update/Check.
-            NextValue(sr_cnt, sr_cnt - sink.width),
-            If(sr_cnt == 0,
-                sink.ready.eq(1),
-                NextState("SEND-STATUS-DATA"),
-            ),
+            # Drain input events that are still crossing the IDDR/fabric pipeline.
+            If(clkgen.sample,
+                sr_in_shift.eq(1),
+                If(sr_in_cnt == last_width,
+                    NextState("SEND-STATUS-DATA"),
+                )
+            )
         )
         self.comb += source.data.eq(sr_in)
         fsm.act("SEND-STATUS-DATA",
-            # Send Data In to Core and return to WAIT when accepted.
             source.valid.eq(1),
             If(source.ready,
                 NextState("WAIT-CMD-DATA"),

--- a/test/test_phy_ddr.py
+++ b/test/test_phy_ddr.py
@@ -12,6 +12,7 @@ from litex.build.io import DDROutput, DDRTristate
 from litex.build.lattice.platform import LatticePlatform
 from litex.build.xilinx.platform import XilinxPlatform
 
+from litespi.clkgen import DDRLiteSPIClkGen
 from litespi.phy.generic_ddr import LiteSPIDDRPHYCore
 
 
@@ -22,7 +23,7 @@ class _DDRBus:
         self.i             = Signal(width)
         self.o             = Signal(width)
         self.oe            = Signal(width)
-        self.input_latency = input_latency
+        self.input_latency = int(2*input_latency)
 
 
 class _SimDDROutputImpl(Module):
@@ -50,8 +51,8 @@ class _SimDDRTristateImpl(Module):
         oe1 = Signal.like(dr.oe1)
         oe2 = Signal.like(dr.oe1)
         # Match the registered DDR input path and model optional platform I/O latency.
-        i1_pipeline = [Signal.like(dr.i1) for _ in range(1 + 2*bus.input_latency)]
-        i2_pipeline = [Signal.like(dr.i2) for _ in range(1 + 2*bus.input_latency)]
+        i1_pipeline = [Signal.like(dr.i1) for _ in range(1 + bus.input_latency)]
+        i2_pipeline = [Signal.like(dr.i2) for _ in range(1 + bus.input_latency)]
 
         self.sync += [
             o1.eq(dr.o1),
@@ -83,10 +84,22 @@ class _SimDDRTristate:
         return _SimDDRTristateImpl(dr, cls.bus)
 
 
+# DDR Clock Generator DUT --------------------------------------------------------------------------
+
+class _DDRLiteSPIClkGenDUT(Module):
+    def __init__(self, extra_latency=0):
+        self.pads = pads = Record([("clk", 1)])
+        self.submodules.clkgen = DDRLiteSPIClkGen(
+            pads          = pads,
+            div_width     = 8,
+            extra_latency = extra_latency,
+        )
+
+
 # DDR PHY DUT --------------------------------------------------------------------------------------
 
 class _LiteSPIDDRPHYDUT(Module):
-    def __init__(self, width, extra_latency):
+    def __init__(self, width, extra_latency, default_divisor=1):
         self.clock_domains.cd_sys_n = ClockDomain(reset_less=True)
 
         if width == 1:
@@ -107,11 +120,12 @@ class _LiteSPIDDRPHYDUT(Module):
 
         self.bus = _DDRBus(io_width, input_latency=extra_latency)
         self.submodules.phy = LiteSPIDDRPHYCore(
-            pads           = pads,
-            flash          = None,
-            extra_latency  = extra_latency,
-            cs_delay       = 0,
-            with_sdr_cs    = False,
+            pads            = pads,
+            flash           = None,
+            extra_latency   = extra_latency,
+            default_divisor = default_divisor,
+            cs_delay        = 0,
+            with_sdr_cs     = False,
         )
 
 
@@ -145,6 +159,67 @@ class _LiteSPIDDRPHYElaborationDUT(Module):
 
 # DDR PHY Tests ------------------------------------------------------------------------------------
 
+class TestDDRLiteSPIClkGen(unittest.TestCase):
+    def test_extra_latency_validation(self):
+        for extra_latency in [-0.5, 0.25]:
+            with self.subTest(extra_latency=extra_latency):
+                with self.assertRaisesRegex(ValueError, "multiple of 0.5"):
+                    _DDRLiteSPIClkGenDUT(extra_latency=extra_latency)
+
+    def test_divisor_waveforms_and_edges(self):
+        divisors = [(0, 1), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (8, 8)]
+        for requested_divisor, divisor in divisors:
+            with self.subTest(divisor=requested_divisor):
+                dut      = _DDRLiteSPIClkGenDUT()
+                clkgen   = dut.clkgen
+                pairs    = []
+                posedges = []
+                negedges = []
+
+                def generator():
+                    yield clkgen.div.eq(requested_divisor)
+                    yield clkgen.en.eq(1)
+                    yield clkgen.start.eq(1)
+                    yield
+                    yield clkgen.start.eq(0)
+                    yield clkgen.div.eq(7) # The active transfer must continue with the latched value.
+
+                    for _ in range(3*divisor + 1):
+                        pairs.append((yield clkgen.clk))
+                        posedges.append((yield clkgen.posedge))
+                        negedges.append((yield clkgen.negedge))
+                        yield
+
+                run_simulation(
+                    dut,
+                    generator(),
+                    special_overrides = {DDROutput : _SimDDROutput},
+                )
+
+                slots = []
+                for pair in pairs[1:]:
+                    slots += [pair & 0x1, (pair >> 1) & 0x1]
+                posedges = posedges[1:]
+                negedges = negedges[1:]
+
+                expected_slots = ([1]*divisor + [0]*divisor)*3
+                self.assertEqual(slots, expected_slots)
+
+                previous = 0
+                expected_posedges = []
+                expected_negedges = []
+                for i in range(0, len(expected_slots), 2):
+                    lane0 = expected_slots[i + 0]
+                    lane1 = expected_slots[i + 1]
+                    expected_posedges.append((not previous) and lane0)
+                    negedge = (previous and not lane0) | ((lane0 and not lane1) << 1)
+                    expected_negedges.append(negedge)
+                    previous = lane1
+
+                self.assertEqual(posedges, expected_posedges)
+                self.assertEqual(negedges, expected_negedges)
+
+
 class TestLiteSPIDDRPHY(unittest.TestCase):
     # sys_n provides the falling half-cycle used by the behavioral DDR input model.
     clocks = {
@@ -158,11 +233,12 @@ class TestLiteSPIDDRPHY(unittest.TestCase):
     }
 
     @staticmethod
-    def _transfer(phy, data, length, width, mask):
+    def _transfer(phy, data, length, width, mask, clk_div=0):
         yield phy.sink.data.eq(data)
         yield phy.sink.len.eq(length)
         yield phy.sink.width.eq(width)
         yield phy.sink.mask.eq(mask)
+        yield phy.sink.clk_div.eq(clk_div)
         yield phy.sink.valid.eq(1)
 
         while not (yield phy.sink.ready):
@@ -234,6 +310,102 @@ class TestLiteSPIDDRPHY(unittest.TestCase):
                 self.assertEqual([oe & output_mask for oe, _ in trace], [output_mask]*len(trace))
                 self.assertEqual([data & (2**width - 1) for _, data in trace], groups)
 
+    def test_divided_output_data_and_clock_edges(self):
+        for divisor in [1, 2, 3, 4, 5, 8]:
+            with self.subTest(divisor=divisor):
+                dut     = _LiteSPIDDRPHYDUT(width=4, extra_latency=0, default_divisor=divisor)
+                phy     = dut.phy
+                groups  = list(range(1, 9))
+                data    = 0x12345678
+                rising  = []
+                previous_sck = [0]
+                sample_index = [0]
+                record       = [False]
+
+                def monitor():
+                    yield "passive"
+                    while True:
+                        yield
+                        sck = yield dut.pads.clk
+                        if record[0]:
+                            if not previous_sck[0] and sck:
+                                rising.append((sample_index[0], (yield dut.bus.oe), (yield dut.bus.o)))
+                            previous_sck[0] = sck
+                            sample_index[0] += 1
+
+                def generator():
+                    yield phy.source.ready.eq(1)
+                    yield phy.cs.eq(1)
+                    for _ in range(3):
+                        yield
+
+                    record[0] = True
+                    yield from self._transfer(phy, data, 32, 4, 0xf)
+                    record[0] = False
+
+                    yield phy.cs.eq(0)
+                    for _ in range(3):
+                        yield
+
+                    self.assertEqual((yield dut.pads.clk), 0)
+
+                self._run(dut, {
+                    "sys"   : [generator(), monitor()],
+                    "sys_n" : monitor(),
+                })
+
+                self.assertEqual(len(rising), len(groups))
+                self.assertEqual([oe & 0xf for _, oe, _ in rising], [0xf]*len(groups))
+                self.assertEqual([value & 0xf for _, _, value in rising], groups)
+                self.assertEqual(
+                    [rising[i + 1][0] - rising[i][0] for i in range(len(rising) - 1)],
+                    [2*divisor]*(len(rising) - 1),
+                )
+
+    def test_per_transfer_clock_divisor(self):
+        dut          = _LiteSPIDDRPHYDUT(width=1, extra_latency=0, default_divisor=3)
+        phy          = dut.phy
+        data         = 0xa5
+        phase        = [None]
+        sample_index = [0]
+        previous_sck = [0]
+        rising       = {2 : [], 3 : [], 5 : []}
+
+        def monitor():
+            yield "passive"
+            while True:
+                yield
+                sck = yield dut.pads.clk
+                if phase[0] is not None:
+                    if not previous_sck[0] and sck:
+                        rising[phase[0]].append((sample_index[0], (yield dut.bus.o) & 0x1))
+                    previous_sck[0] = sck
+                    sample_index[0] += 1
+
+        def generator():
+            yield phy.source.ready.eq(1)
+            yield phy.cs.eq(1)
+            for _ in range(3):
+                yield
+
+            for divisor, override in [(5, 5), (2, 2), (3, 0)]:
+                phase[0] = divisor
+                yield from self._transfer(phy, data, 8, 1, 0x1, clk_div=override)
+                phase[0] = None
+
+        self._run(dut, {
+            "sys"   : [generator(), monitor()],
+            "sys_n" : monitor(),
+        })
+
+        expected_bits = [(data >> shift) & 0x1 for shift in range(7, -1, -1)]
+        for divisor in [2, 3, 5]:
+            self.assertEqual([value for _, value in rising[divisor]], expected_bits)
+            self.assertEqual(
+                [rising[divisor][i + 1][0] - rising[divisor][i][0] for i in range(7)],
+                [2*divisor]*7,
+            )
+
     def test_input_data_with_extra_latency(self):
         for width in [1, 2, 4, 8]:
             for extra_latency in [0, 1]:
@@ -283,8 +455,70 @@ class TestLiteSPIDDRPHY(unittest.TestCase):
                     })
                     self.assertEqual(len(edges), 32//width)
 
+    def test_divided_input_data_with_extra_latency(self):
+        for divisor in [2, 3, 5]:
+            for width in [1, 4]:
+                for extra_latency in [0, 0.5, 1]:
+                    with self.subTest(divisor=divisor, width=width, extra_latency=extra_latency):
+                        dut = _LiteSPIDDRPHYDUT(
+                            width           = width,
+                            extra_latency   = extra_latency,
+                            default_divisor = divisor,
+                        )
+                        phy      = dut.phy
+                        expected = 0x89abcdef
+                        groups   = [
+                            (expected >> shift) & (2**width - 1)
+                            for shift in range(32 - width, -1, -width)
+                        ]
+                        input_index  = [0]
+                        previous_sck = [0]
+                        sample_index = [0]
+                        rising       = []
+                        record       = [False]
+
+                        def monitor(negedge_index):
+                            yield "passive"
+                            while True:
+                                yield
+                                sck = yield dut.pads.clk
+                                if record[0]:
+                                    if not previous_sck[0] and sck:
+                                        rising.append(sample_index[0])
+                                    previous_sck[0] = sck
+                                    sample_index[0] += 1
+
+                                    if (yield phy.clkgen.negedge[negedge_index]):
+                                        input_index[0] += 1
+                                        if input_index[0] < len(groups):
+                                            value = groups[input_index[0]] << (1 if width == 1 else 0)
+                                            yield dut.bus.i.eq(value)
+
+                        def generator():
+                            yield phy.source.ready.eq(1)
+                            yield phy.cs.eq(1)
+                            yield dut.bus.i.eq(groups[0] << (1 if width == 1 else 0))
+                            for _ in range(3):
+                                yield
+
+                            record[0] = True
+                            result = yield from self._transfer(phy, 0, 32, width, 0)
+                            record[0] = False
+                            self.assertEqual(result, expected)
+
+                        self._run(dut, {
+                            "sys"   : [generator(), monitor(0)],
+                            "sys_n" : monitor(1),
+                        })
+
+                        self.assertEqual(len(rising), 32//width)
+                        self.assertEqual(
+                            [rising[i + 1] - rising[i] for i in range(len(rising) - 1)],
+                            [2*divisor]*(len(rising) - 1),
+                        )
+
     def test_command_address_read_turnaround(self):
-        dut          = _LiteSPIDDRPHYDUT(width=4, extra_latency=1)
+        dut          = _LiteSPIDDRPHYDUT(width=4, extra_latency=1, default_divisor=3)
         phy          = dut.phy
         command      = 0x6b
         address      = 0x123456
@@ -293,26 +527,25 @@ class TestLiteSPIDDRPHY(unittest.TestCase):
         output_bits  = []
         input_edges  = []
         read_active  = [False]
+        input_index  = [0]
+        previous_sck = [0]
 
-        def flash_model():
+        def flash_model(negedge_index):
             yield "passive"
-            input_index = 0
-
             while True:
-                if read_active[0] and input_index == 0:
-                    yield dut.bus.i.eq(input_groups[0])
-
                 yield
-                if not (yield dut.pads.clk):
-                    continue
+                sck = yield dut.pads.clk
+                if not previous_sck[0] and sck:
+                    if (yield dut.bus.oe) & 0x1:
+                        output_bits.append((yield dut.bus.o) & 0x1)
+                    elif read_active[0]:
+                        input_edges.append(1)
+                previous_sck[0] = sck
 
-                if (yield dut.bus.oe) & 0x1:
-                    output_bits.append((yield dut.bus.o) & 0x1)
-                elif read_active[0]:
-                    input_edges.append(1)
-                    input_index += 1
-                    if input_index < len(input_groups):
-                        yield dut.bus.i.eq(input_groups[input_index])
+                if read_active[0] and (yield phy.clkgen.negedge[negedge_index]):
+                    input_index[0] += 1
+                    if input_index[0] < len(input_groups):
+                        yield dut.bus.i.eq(input_groups[input_index[0]])
 
         def generator():
             yield phy.source.ready.eq(1)
@@ -326,6 +559,7 @@ class TestLiteSPIDDRPHY(unittest.TestCase):
             yield from self._transfer(phy, address, 24, 1, 0x1)
             self.assertEqual((yield dut.pads.cs_n), 0)
 
+            yield dut.bus.i.eq(input_groups[0])
             read_active[0] = True
             yield
             result = yield from self._transfer(phy, 0, 32, 4, 0)
@@ -339,8 +573,8 @@ class TestLiteSPIDDRPHY(unittest.TestCase):
             self.assertEqual((yield dut.pads.cs_n), 1)
 
         self._run(dut, {
-            "sys"   : generator(),
-            "sys_n" : flash_model(),
+            "sys"   : [generator(), flash_model(0)],
+            "sys_n" : flash_model(1),
         })
 
         output = 0


### PR DESCRIPTION
## Summary

- Extend the existing generic DDR PHY with configurable SCK division instead of adding a parallel implementation.
- Support integer divisors, including odd values, while retaining a 50 percent duty cycle and the established input-capture edge.
- Latch the selected divisor at transfer start and provide both a default-divisor CSR and the existing per-transfer `clk_div` override.
- Accept input latency in 0.5-cycle steps and preserve divisor-one behavior.

## Background

This is a follow-up to #105 and a clean replacement for #86. The original divided-DDR proposal and Efinix hardware validation were contributed by @maass-hamburg in #86.

This PR is intentionally based on `fix/ddr-phy-timing-validation`; #105 should be merged first.

## Validation

- `pytest -q`: 17 tests and 77 parameterized subtests passed.
- Exact clock and edge timing checked for divisors 0, 1, 2, 3, 4, 5, and 8.
- Input and output paths checked across I/O widths, odd/even divisors, runtime overrides, and latency values 0, 0.5, and 1.
- Command, address, and quad-read turnaround checked with divided SCK and CS held active.
- Generated an Arty SPI-flash design with the expected divisor CSR and derived SPI frequency.
- Elaborated the DDR PHY directly for an Efinix Topaz platform with divisor 3 and 0.5-cycle extra latency.

Hardware validation remains desirable before merge, particularly on the Efinix platforms previously exercised in #86.
