### PR TITLE
phy/generic_sdr: Wait for STARTUPE2 handoff

### DIFF
--- a/litespi/clkgen.py
+++ b/litespi/clkgen.py
@@ -65,6 +65,9 @@ class LiteSPIClkGen(LiteXModule):
 
     en : Signal(), in
         Clock enable input, output clock will be generated if set to 1, 0 resets the core.
+
+    ready : Signal(), out
+        Indicates that vendor-specific clock startup is complete and a transfer can start.
     """
     def __init__(self, pads, device, div_width=8, extra_latency=0):
         self.div        = div        = Signal(div_width)
@@ -73,15 +76,19 @@ class LiteSPIClkGen(LiteXModule):
         self.mode       = mode       = Signal(2)
         self.en         = en         = Signal()
         self.start      = start      = Signal()
+        self.ready      = ready      = Signal()
         cnt             = Signal(div_width - 1)
         en_int          = Signal()
         clk             = Signal()
         half            = Signal(div_width - 1)
 
+        startup_enable = 0
+        startup_ready  = 1
+
         self.comb += half.eq((div + 1) >> 1)
 
         self.comb += [
-            posedge.eq( (en | en_int)  & ~clk & (cnt <= 1)),
+            posedge.eq((en | en_int) & ~clk & (cnt <= 1)),
             negedge.eq(clk & (cnt <= 1)),
         ]
 
@@ -133,9 +140,12 @@ class LiteSPIClkGen(LiteXModule):
                     i_USRDONEO  = 1,
                     i_USRDONETS = 1,
                 )
-                # startupe2 needs 3 usrcclko cycles to switch over to user clock
-                self.comb += en_int.eq(cycles < 3)
+                # STARTUPE2 needs 3 USRCCLKO cycles to switch over to the user clock.
+                startup_enable = cycles < 3
+                startup_ready  = Signal()
                 self.sync += If(en_int & posedge, cycles.eq(cycles+1))
+                # Account for the register between the internal clock and USRCCLKO.
+                self.sync += startup_ready.eq(~en_int)
             elif device.startswith("LFE5U"):
                 self.specials += Instance("USRMCLK",
                     i_USRMCLKI  = clk_reg,
@@ -145,3 +155,8 @@ class LiteSPIClkGen(LiteXModule):
                 raise NotImplementedError
         else:
             self.specials += SDROutput(i=clk, o=pads.clk)
+
+        self.comb += [
+            en_int.eq(startup_enable),
+            ready.eq(startup_ready),
+        ]

--- a/litespi/phy/generic_sdr.py
+++ b/litespi/phy/generic_sdr.py
@@ -94,7 +94,10 @@ class LiteSPISDRPHYCore(LiteXModule):
         self.submodules += ResyncReg(mode.storage, clkgen.mode, clock_domain)
 
         # CS control.
-        self.cs_control = cs_control = LiteSPICSControl(pads, self.cs, **kwargs)
+        cs = Signal().like(self.cs)
+        # Keep the flash deselected until vendor-specific clock startup is complete.
+        self.comb += cs.eq(self.cs & Replicate(clkgen.ready, len(self.cs)))
+        self.cs_control = cs_control = LiteSPICSControl(pads, cs, **kwargs)
 
         spi_clk_divisor_delayed = Signal(len(sink.clk_div))
 

--- a/test/test_phy_sdr.py
+++ b/test/test_phy_sdr.py
@@ -1,0 +1,148 @@
+#
+# This file is part of LiteSPI.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+from migen.fhdl.specials import Instance
+from migen.sim import run_simulation
+
+from litespi.clkgen import LiteSPIClkGen
+from litespi.phy.generic_sdr import LiteSPISDRPHYCore
+
+
+class _SPIPads:
+    def __init__(self):
+        self.cs_n = Signal(reset=1)
+        self.mosi = Signal()
+        self.miso = Signal()
+
+
+class _ClockPads:
+    def __init__(self, with_clk):
+        if with_clk:
+            self.clk = Signal()
+
+
+class _LiteSPISDRPHYDUT(Module):
+    def __init__(self):
+        self.pads = _SPIPads()
+        self.submodules.phy = LiteSPISDRPHYCore(
+            pads            = self.pads,
+            flash           = None,
+            device          = "xc7a35t",
+            clock_domain    = "sys",
+            default_divisor = 8,
+            cs_delay        = 10,
+        )
+
+
+class _IgnoreInstance:
+    @staticmethod
+    def lower(instance):
+        return Module()
+
+
+class TestLiteSPISDRPHY(unittest.TestCase):
+    def test_startup_ready_without_startupe2(self):
+        for device, with_clk in [("xc7a35t", True), ("LFE5U-45F", False)]:
+            with self.subTest(device=device, with_clk=with_clk):
+                dut = Module()
+                dut.submodules.clkgen = LiteSPIClkGen(
+                    pads   = _ClockPads(with_clk),
+                    device = device,
+                )
+
+                def generator():
+                    self.assertEqual((yield dut.clkgen.ready), 1)
+                    yield
+                    self.assertEqual((yield dut.clkgen.ready), 1)
+
+                run_simulation(
+                    dut,
+                    generator(),
+                    special_overrides = {Instance : _IgnoreInstance},
+                )
+
+    @staticmethod
+    def _run_first_transfer(idle_cycles):
+        dut       = _LiteSPISDRPHYDUT()
+        completed = []
+
+        def generator():
+            yield dut.phy.clk_divisor.storage.eq(8)
+            yield dut.phy.source.ready.eq(1)
+            for _ in range(idle_cycles):
+                yield
+
+            yield dut.phy.cs.eq(1)
+            yield dut.phy.sink.data.eq(0x9f)
+            yield dut.phy.sink.len.eq(8)
+            yield dut.phy.sink.width.eq(1)
+            yield dut.phy.sink.mask.eq(1)
+            yield dut.phy.sink.valid.eq(1)
+
+            accepted = False
+            for cycle in range(200):
+                if (yield dut.phy.sink.ready):
+                    accepted = True
+                    yield dut.phy.sink.valid.eq(0)
+
+                if (yield dut.phy.source.valid):
+                    completed.append((accepted, cycle))
+                    break
+                yield
+
+        run_simulation(
+            dut,
+            generator(),
+            special_overrides = {Instance : _IgnoreInstance},
+        )
+        return completed
+
+    def test_first_transfer_waits_for_startup(self):
+        # Sweep the first request across startup and an entire SCK period. This includes the
+        # boundary where transfer start previously coincided with the last STARTUPE2 edge.
+        for idle_cycles in range(64):
+            with self.subTest(idle_cycles=idle_cycles):
+                completed = self._run_first_transfer(idle_cycles)
+                self.assertTrue(completed)
+                self.assertTrue(completed[0][0])
+
+    def test_cs_stays_inactive_during_startup(self):
+        dut          = _LiteSPISDRPHYDUT()
+        accepted     = []
+        cs_errors    = []
+        ready_errors = []
+
+        def generator():
+            yield dut.phy.clk_divisor.storage.eq(8)
+            yield dut.phy.cs.eq(1)
+            yield dut.phy.sink.data.eq(0x9f)
+            yield dut.phy.sink.len.eq(8)
+            yield dut.phy.sink.width.eq(1)
+            yield dut.phy.sink.mask.eq(1)
+            yield dut.phy.sink.valid.eq(1)
+
+            for cycle in range(64):
+                startup_ready = yield dut.phy.clkgen.ready
+                if not startup_ready and not (yield dut.pads.cs_n):
+                    cs_errors.append(cycle)
+                if (yield dut.phy.sink.ready):
+                    accepted.append(cycle)
+                    if not startup_ready:
+                        ready_errors.append(cycle)
+                    break
+                yield
+
+        run_simulation(
+            dut,
+            generator(),
+            special_overrides = {Instance : _IgnoreInstance},
+        )
+        self.assertTrue(accepted)
+        self.assertEqual(cs_errors, [])
+        self.assertEqual(ready_errors, [])


### PR DESCRIPTION
## Summary

- Expose when vendor-specific SPI clock startup is complete.
- Keep flash CS inactive until the Xilinx 7-series STARTUPE2 handoff has completed.
- Account for the register between the internal clock and `USRCCLKO` before allowing the first transfer.
- Preserve immediate readiness for direct clock pins and the ECP5 `USRMCLK` path.

## Background

#102 fixed the common case by allowing the STARTUPE2 startup counter to advance while the SPI PHY is idle. A boundary remains when transfer `start` coincides with the third startup edge: startup enable takes priority, the clock is not reset, and the first transfer can enter `XFER` with SCK already high.

This change prevents the transfer from reaching the flash until startup is complete. It addresses the clock/CS sequencing directly instead of resetting the PHY FSM after a bad transfer, which could discard an unaccepted response.

Reported and originally investigated by @paulhamsh in #101.

## Validation

- Unmodified master: 63/64 first-transfer launch phases pass; `idle_cycles=12` stalls.
- This branch: all 64/64 launch phases pass.
- CS is checked to remain inactive until clock startup completes.
- Direct-clock and ECP5 paths are checked to remain immediately ready.
- Full test suite: 10 tests and 98 parameterized subtests pass.
- Xilinx AC701 SDR SPI-flash design elaborates successfully with STARTUPE2.

Hardware confirmation on the setup from #101 is requested before merge.

Fixes #101
