### PR TITLE
phy/xilinx: Add STARTUPE3 primary-flash PHY

### DIFF
--- a/litespi/clkgen.py
+++ b/litespi/clkgen.py
@@ -51,6 +51,9 @@ class LiteSPIClkGen(LiteXModule):
     div_width : int
         Width of the ``div`` used for dividing the clock.
 
+    startup_cycles : int
+        Number of clock rising edges required before a transfer can start.
+
     Attributes
     ----------
     div : Signal(8), in
@@ -69,7 +72,10 @@ class LiteSPIClkGen(LiteXModule):
     ready : Signal(), out
         Indicates that vendor-specific clock startup is complete and a transfer can start.
     """
-    def __init__(self, pads, device, div_width=8, extra_latency=0):
+    def __init__(self, pads, device, div_width=8, extra_latency=0, startup_cycles=0):
+        if not isinstance(startup_cycles, int) or startup_cycles < 0:
+            raise ValueError("SPI clock startup_cycles must be a non-negative integer")
+
         self.div        = div        = Signal(div_width)
         self.posedge    = posedge    = Signal()
         self.negedge    = negedge    = Signal()
@@ -81,9 +87,6 @@ class LiteSPIClkGen(LiteXModule):
         en_int          = Signal()
         clk             = Signal()
         half            = Signal(div_width - 1)
-
-        startup_enable = 0
-        startup_ready  = 1
 
         self.comb += half.eq((div + 1) >> 1)
 
@@ -128,7 +131,6 @@ class LiteSPIClkGen(LiteXModule):
             self.sync += clk_reg.eq(clk)
 
             if device.startswith("xc7"):
-                cycles = Signal(4)
                 self.specials += Instance("STARTUPE2",
                     i_CLK       = 0,
                     i_GSR       = 0,
@@ -140,12 +142,7 @@ class LiteSPIClkGen(LiteXModule):
                     i_USRDONEO  = 1,
                     i_USRDONETS = 1,
                 )
-                # STARTUPE2 needs 3 USRCCLKO cycles to switch over to the user clock.
-                startup_enable = cycles < 3
-                startup_ready  = Signal()
-                self.sync += If(en_int & posedge, cycles.eq(cycles+1))
-                # Account for the register between the internal clock and USRCCLKO.
-                self.sync += startup_ready.eq(~en_int)
+                startup_cycles = 3
             elif device.startswith("LFE5U"):
                 self.specials += Instance("USRMCLK",
                     i_USRMCLKI  = clk_reg,
@@ -156,7 +153,16 @@ class LiteSPIClkGen(LiteXModule):
         else:
             self.specials += SDROutput(i=clk, o=pads.clk)
 
-        self.comb += [
-            en_int.eq(startup_enable),
-            ready.eq(startup_ready),
-        ]
+        if startup_cycles:
+            cycles        = Signal(max=startup_cycles + 1)
+            startup_ready = Signal()
+            self.comb += en_int.eq(cycles < startup_cycles)
+            self.sync += If(en_int & posedge, cycles.eq(cycles + 1))
+            # Account for the register between the internal clock and its output.
+            self.sync += startup_ready.eq(~en_int)
+            self.comb += ready.eq(startup_ready)
+        else:
+            self.comb += [
+                en_int.eq(0),
+                ready.eq(1),
+            ]

--- a/litespi/phy/generic.py
+++ b/litespi/phy/generic.py
@@ -12,6 +12,7 @@ from litespi.common import *
 
 from litespi.phy.generic_sdr import LiteSPISDRPHYCore
 from litespi.phy.generic_ddr import LiteSPIDDRPHYCore
+from litespi.phy.xilinx import LiteSPISTARTUPE3
 
 # LiteSPI PHY --------------------------------------------------------------------------------------
 
@@ -78,3 +79,26 @@ class LiteSPIPHY(LiteXModule):
 
     def get_csrs(self):
         return self.spiflash_phy.get_csrs()
+
+
+# LiteSPI Xilinx UltraScale PHY --------------------------------------------------------------------
+
+class LiteSPIXilinxUSPHY(LiteSPIPHY):
+    """LiteSPI SDR PHY for the primary UltraScale configuration flash.
+
+    The PHY routes its clock, chip select, and four data lines through STARTUPE3. It does not
+    request regular platform pads and is intended to be passed to ``SoC.add_spi_flash`` through
+    its ``phy`` argument.
+    """
+
+    def __init__(self, flash, clock_domain="sys", **kwargs):
+        io = LiteSPISTARTUPE3()
+        LiteSPIPHY.__init__(self,
+            pads         = io.pads,
+            flash        = flash,
+            device       = None,
+            clock_domain = clock_domain,
+            rate         = "1:1",
+            io           = io,
+            **kwargs,
+        )

--- a/litespi/phy/generic_sdr.py
+++ b/litespi/phy/generic_sdr.py
@@ -45,6 +45,10 @@ class LiteSPISDRPHYCore(LiteXModule):
     default_divisor : int
         Default frequency divisor for clkgen.
 
+    io : LiteXModule or None
+        Optional backend providing virtual clock/CS pads, split DQ signals, bus width, and
+        startup-cycle requirements.
+
     Attributes
     ----------
     source : Endpoint(spi_phy2core_layout), out
@@ -59,7 +63,7 @@ class LiteSPISDRPHYCore(LiteXModule):
     clk_divisor : CSRStorage
         Register which holds a clock divisor value applied to clkgen.
     """
-    def __init__(self, pads, flash, device, clock_domain, default_divisor=9, extra_latency=0, **kwargs):
+    def __init__(self, pads, flash, device, clock_domain, default_divisor=9, extra_latency=0, io=None, **kwargs):
         self.source           = source = stream.Endpoint(spi_phy2core_layout)
         self.sink             = sink   = stream.Endpoint(spi_core2phy_layout)
         self.cs               = Signal().like(pads.cs_n)
@@ -73,11 +77,18 @@ class LiteSPISDRPHYCore(LiteXModule):
 
         # # #
 
+        if io is not None:
+            if pads is not io.pads:
+                raise ValueError("SPI I/O backend pads must be used by the PHY")
+            self.submodules.io = io
+
         # Resynchronize CSR Clk Divisor to LiteSPI Clk Domain.
         self.submodules += ResyncReg(clk_divisor.storage, spi_clk_divisor, clock_domain)
 
         # Determine SPI Bus width and DQs.
-        if hasattr(pads, "mosi"):
+        if io is not None:
+            bus_width = io.data_width
+        elif hasattr(pads, "mosi"):
             bus_width = 1
         else:
             bus_width = len(pads.dq)
@@ -89,7 +100,14 @@ class LiteSPISDRPHYCore(LiteXModule):
             assert not flash.ddr
 
         # Clock Generator.
-        self.clkgen = clkgen = LiteSPIClkGen(pads, device, div_width=len(sink.clk_div), extra_latency=extra_latency)
+        startup_cycles = 0 if io is None else io.startup_cycles
+        self.clkgen = clkgen = LiteSPIClkGen(
+            pads           = pads,
+            device         = device,
+            div_width      = len(sink.clk_div),
+            extra_latency  = extra_latency,
+            startup_cycles = startup_cycles,
+        )
 
         self.submodules += ResyncReg(mode.storage, clkgen.mode, clock_domain)
 
@@ -103,7 +121,11 @@ class LiteSPISDRPHYCore(LiteXModule):
 
         self.comb += clkgen.div.eq(spi_clk_divisor_delayed)
 
-        if hasattr(pads, "mosi"):
+        if io is not None:
+            dq_o  = io.dq_o
+            dq_i  = io.dq_i
+            dq_oe = io.dq_oe
+        elif hasattr(pads, "mosi"):
             dq_o  = Signal()
             dq_i  = Signal(2)
             dq_oe = Signal() # Unused.

--- a/litespi/phy/xilinx.py
+++ b/litespi/phy/xilinx.py
@@ -1,0 +1,53 @@
+#
+# This file is part of LiteSPI.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+
+from litex.gen import *
+
+
+# Xilinx UltraScale STARTUPE3 ----------------------------------------------------------------------
+
+class LiteSPISTARTUPE3(LiteXModule):
+    """Route registered LiteSPI SDR signals through the UltraScale STARTUPE3 primitive."""
+
+    data_width     = 4
+    startup_cycles = 3
+
+    def __init__(self):
+        self.pads  = pads  = Record([("clk", 1), ("cs_n", 1)])
+        pads.cs_n.reset = 1
+        self.dq_o  = dq_o  = Signal(self.data_width)
+        self.dq_oe = dq_oe = Signal(self.data_width)
+        self.dq_i  = dq_i  = Signal(self.data_width)
+
+        self.do  = do  = Signal(self.data_width)
+        self.dts = dts = Signal(self.data_width, reset=2**self.data_width - 1)
+        self.di  = di  = Signal(self.data_width)
+
+        # Match the registered generic SDR I/O path. STARTUPE3 uses active-high DTS while
+        # LiteSPI uses active-high output enable.
+        self.sync += [
+            do.eq(dq_o),
+            dts.eq(~dq_oe),
+            dq_i.eq(di),
+        ]
+
+        self.specials += Instance("STARTUPE3",
+            i_GSR       = 0,
+            i_GTS       = 0,
+            i_KEYCLEARB = 0,
+            i_PACK      = 0,
+            i_USRCCLKO  = pads.clk,
+            i_USRCCLKTS = 0,
+            i_USRDONEO  = 1,
+            i_USRDONETS = 1,
+            i_FCSBO     = pads.cs_n,
+            i_FCSBTS    = 0,
+            i_DO        = do,
+            i_DTS       = dts,
+            o_DI        = di,
+        )

--- a/test/test_phy_sdr.py
+++ b/test/test_phy_sdr.py
@@ -47,6 +47,16 @@ class _IgnoreInstance:
 
 
 class TestLiteSPISDRPHY(unittest.TestCase):
+    def test_startup_cycles_validation(self):
+        for startup_cycles in [-1, 0.5]:
+            with self.subTest(startup_cycles=startup_cycles):
+                with self.assertRaisesRegex(ValueError, "non-negative integer"):
+                    LiteSPIClkGen(
+                        pads           = _ClockPads(with_clk=True),
+                        device         = None,
+                        startup_cycles = startup_cycles,
+                    )
+
     def test_startup_ready_without_startupe2(self):
         for device, with_clk in [("xc7a35t", True), ("LFE5U-45F", False)]:
             with self.subTest(device=device, with_clk=with_clk):

--- a/test/test_phy_xilinx.py
+++ b/test/test_phy_xilinx.py
@@ -1,0 +1,213 @@
+#
+# This file is part of LiteSPI.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+from migen.fhdl.specials import Instance
+from migen.sim import run_simulation
+
+from litex.build.xilinx.platform import XilinxUSPlatform
+
+from litespi.phy.generic import LiteSPIXilinxUSPHY
+from litespi.phy.xilinx import LiteSPISTARTUPE3
+
+
+class _IgnoreInstance:
+    @staticmethod
+    def lower(instance):
+        return Module()
+
+
+class _LiteSPIXilinxUSDUT(Module):
+    def __init__(self, default_divisor=4):
+        self.clock_domains.cd_sys = ClockDomain()
+        self.submodules.phy = LiteSPIXilinxUSPHY(
+            flash           = None,
+            default_divisor = default_divisor,
+            cs_delay        = 0,
+        )
+
+
+class TestLiteSPISTARTUPE3(unittest.TestCase):
+    def test_registered_dq_mapping(self):
+        dut = LiteSPISTARTUPE3()
+
+        def generator():
+            self.assertEqual((yield dut.dts), 0xf)
+            yield dut.dq_o.eq(0xa)
+            yield dut.dq_oe.eq(0x5)
+            yield dut.di.eq(0xc)
+            yield
+            yield
+            self.assertEqual((yield dut.do), 0xa)
+            self.assertEqual((yield dut.dts), 0xa)
+            self.assertEqual((yield dut.dq_i), 0xc)
+
+        run_simulation(
+            dut,
+            generator(),
+            special_overrides = {Instance : _IgnoreInstance},
+        )
+
+    def test_instance_port_mapping(self):
+        dut       = _LiteSPIXilinxUSDUT()
+        core      = dut.phy.spiflash_phy
+        io        = core.io
+        fragment  = dut.get_fragment()
+        instances = [
+            special for special in fragment.specials
+            if isinstance(special, Instance) and special.of == "STARTUPE3"
+        ]
+        self.assertEqual(len(instances), 1)
+
+        ports = {
+            item.name: item.expr
+            for item in instances[0].items
+            if hasattr(item, "expr")
+        }
+        self.assertIs(ports["USRCCLKO"], io.pads.clk)
+        self.assertIs(ports["FCSBO"], io.pads.cs_n)
+        self.assertIs(ports["DO"], io.do)
+        self.assertIs(ports["DTS"], io.dts)
+        self.assertIs(ports["DI"], io.di)
+        self.assertEqual(len(ports["DO"]), 4)
+        self.assertEqual(len(ports["DTS"]), 4)
+        self.assertEqual(len(ports["DI"]), 4)
+
+    def test_ultrascale_elaboration(self):
+        platform = XilinxUSPlatform("xcku5p-ffvb676-2-e", [], toolchain="vivado")
+        verilog  = str(platform.get_verilog(_LiteSPIXilinxUSDUT(), name="top"))
+        self.assertEqual(verilog.count("STARTUPE3 STARTUPE3"), 1)
+        for port in ["USRCCLKO", "FCSBO", "FCSBTS", "DO", "DTS", "DI"]:
+            self.assertIn(f".{port}", verilog)
+
+
+class TestLiteSPIXilinxUSPHY(unittest.TestCase):
+    @staticmethod
+    def _transfer(core, data, length, width, mask):
+        yield core.sink.data.eq(data)
+        yield core.sink.len.eq(length)
+        yield core.sink.width.eq(width)
+        yield core.sink.mask.eq(mask)
+        yield core.sink.valid.eq(1)
+
+        while not (yield core.sink.ready):
+            yield
+        yield core.sink.valid.eq(0)
+
+        while not (yield core.source.valid):
+            yield
+        return (yield core.source.data)
+
+    def test_first_transfer_phases(self):
+        for idle_cycles in range(32):
+            with self.subTest(idle_cycles=idle_cycles):
+                dut       = _LiteSPIXilinxUSDUT()
+                core      = dut.phy.spiflash_phy
+                completed = []
+
+                def generator():
+                    yield core.source.ready.eq(1)
+                    for _ in range(idle_cycles):
+                        yield
+                    yield core.cs.eq(1)
+                    yield from self._transfer(core, 0xa, 4, 4, 0xf)
+                    completed.append(1)
+
+                run_simulation(
+                    dut,
+                    generator(),
+                    special_overrides = {Instance : _IgnoreInstance},
+                )
+                self.assertEqual(completed, [1])
+
+    def test_output_data_and_direction(self):
+        cases = [
+            (1, 0xa5, 8, 0x1, [1, 0, 1, 0, 0, 1, 0, 1], 0xe),
+            (4, 0x12345678, 32, 0xf, list(range(1, 9)), 0x0),
+        ]
+        for width, data, length, mask, expected, expected_dts in cases:
+            with self.subTest(width=width):
+                dut       = _LiteSPIXilinxUSDUT()
+                core      = dut.phy.spiflash_phy
+                io        = core.io
+                edges     = []
+                cs_errors = []
+
+                def monitor():
+                    yield "passive"
+                    previous = 0
+                    while True:
+                        yield
+                        clk = yield io.pads.clk
+                        if not (yield core.clkgen.ready) and not (yield io.pads.cs_n):
+                            cs_errors.append(1)
+                        if not previous and clk and not (yield io.pads.cs_n):
+                            edges.append(((yield io.do), (yield io.dts)))
+                        previous = clk
+
+                def generator():
+                    yield core.source.ready.eq(1)
+                    yield core.cs.eq(1)
+                    yield from self._transfer(core, data, length, width, mask)
+
+                run_simulation(
+                    dut,
+                    [generator(), monitor()],
+                    special_overrides = {Instance : _IgnoreInstance},
+                )
+                self.assertEqual([value & (2**width - 1) for value, _ in edges], expected)
+                self.assertEqual([dts for _, dts in edges], [expected_dts]*len(expected))
+                self.assertEqual(cs_errors, [])
+
+    def test_input_data_and_direction(self):
+        for width in [1, 4]:
+            with self.subTest(width=width):
+                dut      = _LiteSPIXilinxUSDUT()
+                core     = dut.phy.spiflash_phy
+                io       = core.io
+                expected = 0x89abcdef
+                groups   = [
+                    (expected >> shift) & (2**width - 1)
+                    for shift in range(32 - width, -1, -width)
+                ]
+                edges    = []
+                result   = []
+
+                def flash_model():
+                    yield "passive"
+                    previous   = 0
+                    index      = 0
+                    saw_rising = False
+                    value      = groups[0] << (1 if width == 1 else 0)
+                    yield io.di.eq(value)
+
+                    while True:
+                        yield
+                        clk = yield io.pads.clk
+                        if not previous and clk and not (yield io.pads.cs_n):
+                            saw_rising = True
+                            edges.append((yield io.dts))
+                        if saw_rising and previous and not clk and not (yield io.pads.cs_n):
+                            index += 1
+                            if index < len(groups):
+                                value = groups[index] << (1 if width == 1 else 0)
+                                yield io.di.eq(value)
+                        previous = clk
+
+                def generator():
+                    yield core.source.ready.eq(1)
+                    yield core.cs.eq(1)
+                    result.append((yield from self._transfer(core, 0, 32, width, 0)))
+
+                run_simulation(
+                    dut,
+                    [generator(), flash_model()],
+                    special_overrides = {Instance : _IgnoreInstance},
+                )
+                self.assertEqual(result, [expected])
+                self.assertEqual(edges, [0xf]*len(groups))


### PR DESCRIPTION
## Summary

- add a dedicated STARTUPE3 backend for the UltraScale/UltraScale+ primary flash
- expose `LiteSPIXilinxUSPHY` for SDR x1/x4 memory-mapped access without regular flash pads
- reuse the startup handoff sequencing from #107 and keep chip select inactive until it completes
- leave the existing physical-pad PHY paths unchanged

## Background

This follows the feature request and hardware proof of concept shared by @jersey99 in #78. The implementation keeps the Xilinx configuration primitive behind a small I/O backend instead of adding device-specific behavior to the generic clock generator or relying on device-name detection.

The PR is stacked on #107 because STARTUPE3 requires the same configuration-clock handoff protection as STARTUPE2. #107 should be merged first.

## Usage

```python
phy = LiteSPIXilinxUSPHY(
    flash           = flash,
    default_divisor = 2,
)
self.add_spi_flash(
    mode        = "4x",
    module      = flash,
    phy         = phy,
    with_master = True,
)
```

No regular platform flash resource is requested: the PHY reaches the primary flash through `STARTUPE3`.

## Validation

- LiteSPI test suite: 17 tests and 136 subtests pass
- exact x1/x4 input, output, and direction sequencing is covered
- the first transfer is exercised at 32 launch phases around the startup handoff
- generated Verilog and the `STARTUPE3` primitive port map are checked
- a complete VCU118 Vivado 2024.1 build generated a bitstream with one `STARTUPE3`, no regular top-level flash pins, and no related DRC errors
- post-route timing for that smoke build: WNS +1.259 ns, WHS +0.028 ns

Hardware validation on the original setup is still requested before considering the feature fully proven.

Fixes #78
